### PR TITLE
Set LINK_LIBRARIES for try_run to CMAKE_EXE_LINKER_FLAGS

### DIFF
--- a/cmake/ecbuild_try_run.cmake
+++ b/cmake/ecbuild_try_run.cmake
@@ -127,6 +127,10 @@ function( ecbuild_try_run RUN_RESULT_VAR COMPILE_RESULT_VAR BINDIR SRCFILE )
     ecbuild_critical("Unknown keywords given to ecbuild_try_run(): \"${_p_UNPARSED_ARGUMENTS}\"")
   endif()
 
+  if( CMAKE_EXE_LINKER_FLAGS )
+    set( _p_LINK_LIBRARIES "${_p_LINK_LIBRARIES} ${CMAKE_EXE_LINKER_FLAGS}" )
+  endif()
+
   # Build argument list for try_compile
   foreach( _opt CMAKE_FLAGS COMPILE_DEFINITIONS LINK_LIBRARIES  )
     if( _p_${_opt} )


### PR DESCRIPTION
Set LINK_LIBRARIES to CMAKE_EXE_LINKER_FLAGS (if set) in ecbuild_try_run.  Setting of e.g. rpath in CMAKE_EXE_LINKER_FLAGS may be necessary for an executable to run; this allows such settings to be passed to the compilation of the test executable.