### PR TITLE
Windows: fix the path used to replace symlinks

### DIFF
--- a/cmake/ecbuild_check_os.cmake
+++ b/cmake/ecbuild_check_os.cmake
@@ -381,7 +381,7 @@ if( WIN32 )
   ecbuild_warn( "CMake doesn't support symlinks on Windows. "
                 "Replacing all symlinks with copies." )
   execute_process( COMMAND bash -c "${ECBUILD_MACROS_DIR}/ecbuild_windows_replace_symlinks.sh"
-                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/cmake
+                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                    RESULT_VARIABLE CMD_RESULT
                    OUTPUT_VARIABLE CMD_OUTPUT
                    ERROR_VARIABLE  CMD_ERROR )

--- a/cmake/ecbuild_windows_replace_symlinks.sh
+++ b/cmake/ecbuild_windows_replace_symlinks.sh
@@ -21,7 +21,7 @@ echo " REMOVING ALL SYMLINKS "
 echo "======================="
 echo ""
 
-for link in `find .. -type l -not -path '../build/*'`
+for link in `find . -type l -not -path './build/*'`
 do
     if [ -e $link ]
     then


### PR DESCRIPTION
${PROJECT_SOURCE_DIR}/cmake may not necessarily exist. Since we want to
work in ${PROJECT_SOURCE_DIR}, we make this the working directory
directly.