### PR TITLE
Windows: fix path to windows testing bashrc

### DIFF
--- a/cmake/ecbuild_add_test.cmake
+++ b/cmake/ecbuild_add_test.cmake
@@ -459,7 +459,7 @@ macro( ecbuild_add_test )
 
       if( EC_OS_NAME MATCHES "windows" AND ${_PAR_TYPE} MATCHES "SCRIPT" )
         # Windows has to be explicitly told to use bash for the tests.
-        set( _WIN_CMD "bash" "--rcfile" "${CMAKE_CURRENT_SOURCE_DIR}/windows_testing.bashrc" "-ci" )
+        set( _WIN_CMD "bash" "--rcfile" "${WINDOWS_TESTING_BASHRC_DIR}/windows_testing.bashrc" "-ci" )
       else()
         set( _WIN_CMD "" )
       endif()

--- a/cmake/ecbuild_add_test.cmake
+++ b/cmake/ecbuild_add_test.cmake
@@ -459,7 +459,10 @@ macro( ecbuild_add_test )
 
       if( EC_OS_NAME MATCHES "windows" AND ${_PAR_TYPE} MATCHES "SCRIPT" )
         # Windows has to be explicitly told to use bash for the tests.
-        set( _WIN_CMD "bash" "--rcfile" "${WINDOWS_TESTING_BASHRC_DIR}/windows_testing.bashrc" "-ci" )
+        if( NOT DEFINED WINDOWS_TESTING_BASHRC )
+            set( WINDOWS_TESTING_BASHRC "${CMAKE_CURRENT_SOURCE_DIR}/windows_testing.bashrc" )
+        endif()
+        set( _WIN_CMD "bash" "--rcfile" "${WINDOWS_TESTING_BASHRC}" "-ci" )
       else()
         set( _WIN_CMD "" )
       endif()


### PR DESCRIPTION
This commit allows users to specify the path to the windows testing
bashrc for their project instead of assuming where the file will be
found.