### PR TITLE
Search for proj_6_0.lib if proj.lib isn't found

### DIFF
--- a/cmake/FindProj4.cmake
+++ b/cmake/FindProj4.cmake
@@ -44,13 +44,13 @@ endif()
 
 if( PROJ4_PATH )
 
-    find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h PATHS ${PROJ4_PATH} ${PROJ4_PATH}/include PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
-    find_library(PROJ4_LIBRARY  NAMES proj       PATHS ${PROJ4_PATH} ${PROJ4_PATH}/lib     PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
+    find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h    PATHS ${PROJ4_PATH} ${PROJ4_PATH}/include PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
+    find_library(PROJ4_LIBRARY  NAMES proj proj_6_0 PATHS ${PROJ4_PATH} ${PROJ4_PATH}/lib     PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
 
 endif()
 
-find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h PATHS PATH_SUFFIXES proj4 )
-find_library( PROJ4_LIBRARY NAMES proj       PATHS PATH_SUFFIXES proj4 )
+find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h    PATHS PATH_SUFFIXES proj4 )
+find_library( PROJ4_LIBRARY NAMES proj proj_6_0 PATHS PATH_SUFFIXES proj4 )
 
 
 # handle the QUIETLY and REQUIRED arguments and set GRIBAPI_FOUND

--- a/cmake/FindProj4.cmake
+++ b/cmake/FindProj4.cmake
@@ -42,15 +42,17 @@ if( NOT PROJ4_PATH )
 
 endif()
 
+set( _proj4_lib_names proj proj_6_0 )
+
 if( PROJ4_PATH )
 
-    find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h    PATHS ${PROJ4_PATH} ${PROJ4_PATH}/include PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
-    find_library(PROJ4_LIBRARY  NAMES proj proj_6_0 PATHS ${PROJ4_PATH} ${PROJ4_PATH}/lib     PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
+    find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h          PATHS ${PROJ4_PATH} ${PROJ4_PATH}/include PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
+    find_library(PROJ4_LIBRARY  NAMES ${_proj4_lib_names} PATHS ${PROJ4_PATH} ${PROJ4_PATH}/lib     PATH_SUFFIXES proj4 NO_DEFAULT_PATH )
 
 endif()
 
-find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h    PATHS PATH_SUFFIXES proj4 )
-find_library( PROJ4_LIBRARY NAMES proj proj_6_0 PATHS PATH_SUFFIXES proj4 )
+find_path(PROJ4_INCLUDE_DIR NAMES proj_api.h          PATHS PATH_SUFFIXES proj4 )
+find_library( PROJ4_LIBRARY NAMES ${_proj4_lib_names} PATHS PATH_SUFFIXES proj4 )
 
 
 # handle the QUIETLY and REQUIRED arguments and set GRIBAPI_FOUND


### PR DESCRIPTION
On Windows we install proj4 from conda. The proj4 v6 package doesn't
contain proj.lib - instead it has proj_6_0.lib. This change allows ECMWF
cmake packages to find proj4 v6 on Windows.

See https://github.com/conda-forge/magics-feedstock/pull/35 for motivation.
