### PR TITLE
allow ecbuild_git to checkout git submodules

### DIFF
--- a/cmake/ecbuild_bundle.cmake
+++ b/cmake/ecbuild_bundle.cmake
@@ -64,8 +64,9 @@ endmacro()
 #   ecbuild_bundle( PROJECT <name>
 #                   STASH <repository> | GIT <giturl> | SOURCE <path>
 #                   [ BRANCH <gitbranch> | TAG <gittag> ]
-#                   [ UPDATE | NOREMOTE ] )
-#                   [ MANUAL ] )
+#                   [ UPDATE | NOREMOTE ]
+#                   [ MANUAL ]
+#                   [ RECURSIVE ] )
 #
 # Options
 # -------
@@ -96,6 +97,9 @@ endmacro()
 #
 # MANUAL : optional
 #   Do not automatically switch branches or tags
+#
+# RECURSIVE : optional
+#   Do a recursive fetch or update
 #
 # Usage
 # -----

--- a/cmake/ecbuild_git.cmake
+++ b/cmake/ecbuild_git.cmake
@@ -230,7 +230,7 @@ macro( ecbuild_git )
 
       if( _PAR_RECURSIVE )
         ecbuild_info("git submodule --quiet update --init --recursive @ ${ABS_PAR_DIR}")
-        execute_process( COMMAND "${GIT_EXECUTABLE}" submodule --quiet update --init --recursive -q
+        execute_process( COMMAND "${GIT_EXECUTABLE}" submodule --quiet update --init --recursive
                         RESULT_VARIABLE nok ERROR_VARIABLE error
                         WORKING_DIRECTORY "${ABS_PAR_DIR}")
         if(nok)
@@ -243,4 +243,3 @@ macro( ecbuild_git )
   endif( ECBUILD_GIT )
 
 endmacro()
-

--- a/cmake/ecbuild_git.cmake
+++ b/cmake/ecbuild_git.cmake
@@ -26,8 +26,9 @@ endif()
 #                DIR <directory>
 #                URL <giturl>
 #                [ BRANCH <gitbranch> | TAG <gittag> ]
-#                [ UPDATE | NOREMOTE ] )
-#                [ MANUAL ] )
+#                [ UPDATE | NOREMOTE ]
+#                [ MANUAL ]
+#                [ RECURSIVE ] )
 #
 # Options
 # -------
@@ -56,11 +57,14 @@ endif()
 # MANUAL : optional
 #   Do not automatically switch branches or tags
 #
+# RECURSIVE : optional
+#   Do a recursive fetch or update
+#
 ##############################################################################
 
 macro( ecbuild_git )
 
-  set( options UPDATE NOREMOTE MANUAL )
+  set( options UPDATE NOREMOTE MANUAL RECURSIVE )
   set( single_value_args PROJECT DIR URL TAG BRANCH )
   set( multi_value_args )
   cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}" ${_FIRST_ARG} ${ARGN} )
@@ -223,6 +227,16 @@ macro( ecbuild_git )
         endif()
 
       endif() ####################################################################################
+
+      if( _PAR_RECURSIVE )
+        ecbuild_info("git submodule --quiet update --init --recursive @ ${ABS_PAR_DIR}")
+        execute_process( COMMAND "${GIT_EXECUTABLE}" submodule --quiet update --init --recursive -q
+                        RESULT_VARIABLE nok ERROR_VARIABLE error
+                        WORKING_DIRECTORY "${ABS_PAR_DIR}")
+        if(nok)
+          ecbuild_warn("git submodule update --init --recursive in ${_PAR_DIR} failed:\n ${error}")
+        endif()
+      endif()
 
     endif( _needs_switch AND IS_DIRECTORY "${_PAR_DIR}/.git" )
 

--- a/cmake/ecbuild_git.cmake
+++ b/cmake/ecbuild_git.cmake
@@ -234,7 +234,7 @@ macro( ecbuild_git )
                         RESULT_VARIABLE nok ERROR_VARIABLE error
                         WORKING_DIRECTORY "${ABS_PAR_DIR}")
         if(nok)
-          ecbuild_warn("git submodule update --init --recursive in ${_PAR_DIR} failed:\n ${error}")
+          ecbuild_critical("git submodule update --init --recursive in ${_PAR_DIR} failed:\n ${error}")
         endif()
       endif()
 


### PR DESCRIPTION
For some time now, [JCSDA](https://github.com/jcsda) has been forking third-party repositories. If there are git submodules employed by a repository that is used/co-developed, those submodules have to be forked as well.  Examples (relevant to JCSDA) are `mom6` and it's dependencies e.g. `CVmix`, `geoKdtree`, `mom6-da-hooks` and now `ocean_bgc`.
This adds burden on  the developer to maintain the `ecbuild` layer on these submodules as well as keeping them in sync; i.e. keep a track of the `SHA` in the submodules.

With this option `RECURSIVE`, one can recursively clone/update these via the `ecbuild_bundle`, this makes the job much easier and allows us to obtain the appropriate `SHA` of these dependencies as they relate to the upstream repository.  The appropriate git call `git submodule update --init --recursive` is called when this option is specified in the call to `ecbuild_bundle` or `ecbuild_git`. 

An example of this is demonstrated in `mom6-bundle`. Clone the branch `feature/recursion` from [mom6-bundle](https://github.com/aerorahul/mom6-bundle) and use the branch with the same name in `jcsda::ecbuild`.

Change-Id: I586486448540546e2f360efc25d78a1d1d4f34b6