### PR TITLE
Make generation of the *_GIT_SHA1 variables optional

### DIFF
--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -31,6 +31,10 @@
 # :INSTALL_DATA_DIR:       relative install directory for data
 # :INSTALL_CMAKE_DIR:      relative install directory for CMake files
 #
+# Generation of the first two variables can be disabled by setting the
+# RECORD_GIT_SHA1_IN_VARIABLES option to OFF.  This prevents
+# makefiles from being regenerated whenever the Git revision changes.
+#
 # Customising install locations
 # -----------------------------
 #
@@ -69,7 +73,7 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # if git project get its HEAD SHA1
   # leave it here so we may use ${PROJECT_NAME}_GIT_SHA1 on the version file
 
-  if( EXISTS ${PROJECT_SOURCE_DIR}/.git )
+  if( (${RECORD_GIT_SHA1_IN_VARIABLES}) AND (EXISTS ${PROJECT_SOURCE_DIR}/.git) )
     get_git_head_revision( GIT_REFSPEC ${PROJECT_NAME}_GIT_SHA1 )
     if( ${PROJECT_NAME}_GIT_SHA1 )
       string( SUBSTRING "${${PROJECT_NAME}_GIT_SHA1}" 0 7 ${PROJECT_NAME}_GIT_SHA1_SHORT )

--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -32,7 +32,7 @@
 # :INSTALL_CMAKE_DIR:      relative install directory for CMake files
 #
 # Generation of the first two variables can be disabled by setting the
-# RECORD_GIT_SHA1_IN_VARIABLES option to OFF.  This prevents
+# ECBUILD_RECORD_GIT_COMMIT_SHA1 option to OFF.  This prevents
 # makefiles from being regenerated whenever the Git revision changes.
 #
 # Customising install locations
@@ -73,7 +73,7 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # if git project get its HEAD SHA1
   # leave it here so we may use ${PROJECT_NAME}_GIT_SHA1 on the version file
 
-  if( (${RECORD_GIT_SHA1_IN_VARIABLES}) AND (EXISTS ${PROJECT_SOURCE_DIR}/.git) )
+  if( (${ECBUILD_RECORD_GIT_COMMIT_SHA1}) AND (EXISTS ${PROJECT_SOURCE_DIR}/.git) )
     get_git_head_revision( GIT_REFSPEC ${PROJECT_NAME}_GIT_SHA1 )
     if( ${PROJECT_NAME}_GIT_SHA1 )
       string( SUBSTRING "${${PROJECT_NAME}_GIT_SHA1}" 0 7 ${PROJECT_NAME}_GIT_SHA1_SHORT )

--- a/cmake/ecbuild_define_options.cmake
+++ b/cmake/ecbuild_define_options.cmake
@@ -36,6 +36,7 @@ option( ECBUILD_INSTALL_FORTRAN_MODULES "Will install Fortran modules" ON )
 mark_as_advanced( ECBUILD_INSTALL_FORTRAN_MODULES )
 
 option( ECBUILD_RECORD_GIT_COMMIT_SHA1 "When building ecbuild projects that are Git repos, create variables recording the full and short Git revision" ON )
+mark_as_advanced( ECBUILD_RECORD_GIT_COMMIT_SHA1 )
 
 include( CMakeDependentOption ) # make options depend on one another
 

--- a/cmake/ecbuild_define_options.cmake
+++ b/cmake/ecbuild_define_options.cmake
@@ -35,6 +35,8 @@ mark_as_advanced( ECBUILD_INSTALL_LIBRARY_HEADERS )
 option( ECBUILD_INSTALL_FORTRAN_MODULES "Will install Fortran modules" ON )
 mark_as_advanced( ECBUILD_INSTALL_FORTRAN_MODULES )
 
+option( RECORD_GIT_SHA1_IN_VARIABLES "When building ecbuild projects that are Git repos, create variables recording the full and short Git revision" ON )
+
 include( CMakeDependentOption ) # make options depend on one another
 
 set( CMAKE_NO_SYSTEM_FROM_IMPORTED ON )

--- a/cmake/ecbuild_define_options.cmake
+++ b/cmake/ecbuild_define_options.cmake
@@ -35,7 +35,7 @@ mark_as_advanced( ECBUILD_INSTALL_LIBRARY_HEADERS )
 option( ECBUILD_INSTALL_FORTRAN_MODULES "Will install Fortran modules" ON )
 mark_as_advanced( ECBUILD_INSTALL_FORTRAN_MODULES )
 
-option( RECORD_GIT_SHA1_IN_VARIABLES "When building ecbuild projects that are Git repos, create variables recording the full and short Git revision" ON )
+option( ECBUILD_RECORD_GIT_COMMIT_SHA1 "When building ecbuild projects that are Git repos, create variables recording the full and short Git revision" ON )
 
 include( CMakeDependentOption ) # make options depend on one another
 


### PR DESCRIPTION
For projects in Git repositories, ecbuild generates variables recording the hash of the git revision at the time of the last build. This is no doubt useful in production, but it is awkward during development, since it causes CMake to be re-run after each Git commit, which can be time-consuming for large projects. This PR adds an option to disable generation of these variables.

As things stand, this option is not marked as advanced, but I'm happy to mark it as such.