### PR TITLE
Use CMAKE_INSTALL_LIBDIR as default for INSTALL_LIB_DIR

### DIFF
--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -114,7 +114,7 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # install dirs for this project
 
   # Use defaults unless values are already present in cache
-  include(GNUInstalDirs)
+  include(GNUInstallDirs)
   if( NOT INSTALL_BIN_DIR )
     set( INSTALL_BIN_DIR bin )
   endif()

--- a/cmake/ecbuild_declare_project.cmake
+++ b/cmake/ecbuild_declare_project.cmake
@@ -114,11 +114,12 @@ if( NOT ${PROJECT_NAME}_DECLARED )
   # install dirs for this project
 
   # Use defaults unless values are already present in cache
+  include(GNUInstalDirs)
   if( NOT INSTALL_BIN_DIR )
     set( INSTALL_BIN_DIR bin )
   endif()
   if( NOT INSTALL_LIB_DIR )
-    set( INSTALL_LIB_DIR lib )
+    set( INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR} )
   endif()
   if( NOT INSTALL_INCLUDE_DIR )
     set( INSTALL_INCLUDE_DIR include )


### PR DESCRIPTION
Ecbuild hardcodes the default library install location to `lib`, which is not a valid library install location on many platforms, e.g., those that use `lib64` or multi-tiered `lib/<multi-arch>` directories with multiarch support.  The [CMake GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) module sets the default CMake install locations on a per-platform basis.  Defaulting the `INSTALL_LIB_DIR` to the value of `CMAKE_INSTALL_LIBDIR` will allow ecbuild enabled packages to be installed to the correct system-dependent locations, as determined by CMake.