### PR TITLE
Make line ending of generated .md5 compatible with one in the output …

### DIFF
--- a/cmake/ecbuild_get_test_data.cmake
+++ b/cmake/ecbuild_get_test_data.cmake
@@ -217,7 +217,7 @@ function( ecbuild_get_test_data )
                                 COMMAND ${CMAKE_COMMAND} -E md5sum ${_p_NAME} > ${_p_NAME}.localmd5
                                 DEPENDS ${_p_NAME} )
 
-            configure_file( "${ECBUILD_MACROS_DIR}/md5.in" ${_p_NAME}.md5 @ONLY )
+            configure_file( "${ECBUILD_MACROS_DIR}/md5.in" ${_p_NAME}.md5 @ONLY NEWLINE_STYLE LF )
 
             add_custom_command( OUTPUT ${_p_NAME}.ok
                                 COMMAND ${CMAKE_COMMAND} -E compare_files ${_p_NAME}.md5 ${_p_NAME}.localmd5 &&


### PR DESCRIPTION
…of 'cmake -E md5sum' command.

It seems configure_file() by default forces platform specific line ending in the output whereas 'cmake -E md5sum ...' emits LF regardless of the platform.  That results in failure of 'cmake -E compare_files' on Windows. I think ultimately cmake should be fixed for consistent behavior but I'm afraid it's too late for that to happen. Without this patch, AppVeyor test for https://github.com/ecmwf/eccodes/pull/41 fails.