### PR TITLE
Search component specific paths for NetCDF libraries as well as includes

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -120,7 +120,7 @@ foreach( _comp ${_search_components} )
   find_library(NetCDF_${_comp}_LIBRARY
     NAMES ${NetCDF_${_comp}_LIBRARY_NAME}
     DOC "netcdf ${_comp} library"
-    HINTS ${_search_hints}
+    HINTS ${_search_hints_${_comp}} ${_search_hints}
     PATH_SUFFIXES lib ../../lib
   )
   mark_as_advanced(NetCDF_${_comp}_LIBRARY)


### PR DESCRIPTION
This is a hopefully clearer explanation of my proposed fix for https://github.com/ecmwf/ecbuild/issues/46.  It ensures that component specific paths for NetCDF libraries are searched as well as for the includes; currently only the non component specific paths are searched for libraries.