### PR TITLE
Replace no longer supported -Gfast Cray flag

### DIFF
--- a/cmake/compiler_flags/Cray_C.cmake
+++ b/cmake/compiler_flags/Cray_C.cmake
@@ -7,7 +7,7 @@
 # nor does it submit to any jurisdiction.
 
 set( CMAKE_C_FLAGS_RELEASE        "-O3 -hfp3 -hscalar3 -hvector3 -DNDEBUG"        CACHE STRING "Release C flags"                  FORCE )
-set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -hfp1 -Gfast -DNDEBUG"                     CACHE STRING "Release-with-debug-info C flags"  FORCE )
+set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -hfp1 -G2 -DNDEBUG"                        CACHE STRING "Release-with-debug-info C flags"  FORCE )
 set( CMAKE_C_FLAGS_PRODUCTION     "-O2 -hfp1 -G2"                                 CACHE STRING "Production C flags"               FORCE )
 set( CMAKE_C_FLAGS_BIT            "-O2 -hfp1 -G2 -hflex_mp=conservative -DNDEBUG" CACHE STRING "Bit-reproducible C flags"         FORCE )
 set( CMAKE_C_FLAGS_DEBUG          "-O0 -G0"                                       CACHE STRING "Debug Cflags"                     FORCE )

--- a/cmake/compiler_flags/Cray_CXX.cmake
+++ b/cmake/compiler_flags/Cray_CXX.cmake
@@ -7,7 +7,7 @@
 # nor does it submit to any jurisdiction.
 
 set( CMAKE_CXX_FLAGS_RELEASE        "-O3 -hfp3 -hscalar3 -hvector3 -DNDEBUG"    CACHE STRING "Release C++ flags"                 FORCE )
-set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -hfp1 -Gfast -DNDEBUG"                 CACHE STRING "Release-with-debug-info C++ flags" FORCE )
+set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -hfp1 -G2 -DNDEBUG"                    CACHE STRING "Release-with-debug-info C++ flags" FORCE )
 set( CMAKE_CXX_FLAGS_PRODUCTION     "-O2 -hfp1"                                 CACHE STRING "Production C++ flags"              FORCE )
 set( CMAKE_CXX_FLAGS_BIT            "-O2 -hfp1 -hflex_mp=conservative -DNDEBUG" CACHE STRING "Bit-reproducible C++ flags"        FORCE )
 set( CMAKE_CXX_FLAGS_DEBUG          "-G0 -O0"                                   CACHE STRING "Debug CXX flags"                   FORCE )

--- a/cmake/compiler_flags/Cray_Fortran.cmake
+++ b/cmake/compiler_flags/Cray_Fortran.cmake
@@ -9,7 +9,7 @@
 # -emf activates .mods and uses lower case
 # -rmoid produces a listing file
 set( CMAKE_Fortran_FLAGS_RELEASE        "-emf -rmoid -N 1023 -O3 -hfp3 -hscalar3 -hvector3 -DNDEBUG"                    CACHE STRING "Release Fortran flags"                 FORCE )
-set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-emf -rmoid -N 1023 -O2 -hfp1 -Gfast -DNDEBUG"                                 CACHE STRING "Release-with-debug-info Fortran flags" FORCE )
+set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-emf -rmoid -N 1023 -O2 -hfp1 -G2 -DNDEBUG"                                    CACHE STRING "Release-with-debug-info Fortran flags" FORCE )
 set( CMAKE_Fortran_FLAGS_PRODUCTION     "-emf -rmoid -N 1023 -O2 -hfp1 -G2"                                             CACHE STRING "Production Fortran flags"              FORCE )
 set( CMAKE_Fortran_FLAGS_BIT            "-emf -rmoid -N 1023 -O2 -hfp1 -G2 -hflex_mp=conservative -hadd_paren -DNDEBUG" CACHE STRING "Bit-reproducible Fortran flags"        FORCE )
 set( CMAKE_Fortran_FLAGS_DEBUG          "-emf -rmoid -N 1023 -O0 -G0"                                                   CACHE STRING "Debug Fortran flags"                   FORCE )


### PR DESCRIPTION
With Cray compiler cce/15.0.1

Addresses:
```
ftn-2109 ftn: WARNING in command line
  Option -G fast is no longer supported.  It will be ignored.
  ```