### PR TITLE
CPP out LOC calls for NAG.

### DIFF
--- a/cmake/fortran_features/finalization.F90
+++ b/cmake/fortran_features/finalization.F90
@@ -53,14 +53,18 @@ function AnimalType__ctor(animaltype_) result(self)
   type(AnimalType) :: self
   character(len=*) :: animaltype_
   self%m_kind = animaltype_
+#ifndef NAGFOR
   write(0,'(3A,I0)') "Constructing animal ",self%m_kind, " -- address = ",loc(self)
+#endif
   self%constructed = .true.
 end function
 
 subroutine AnimalType__assignment(animal_out,animal_in)
   type(AnimalType), intent(out) :: animal_out
   class(AnimalType), intent(in) :: animal_in
+#ifndef NAGFOR
   write(0,'(3A,I0,A,I0)') '   Copying ',animal_in%m_kind, " -- from address ", loc(animal_in), " to address ", loc(animal_out)
+#endif
   animal_out%m_kind = animal_in%m_kind
   animal_out%constructed = animal_in%constructed
 end subroutine


### PR DESCRIPTION
Resolves #62.  The LOC intrinsic is only used for some write statements, so it looks like it can be cpp'ed out for NAG.  I can do something more sophisticated if desired, but this change results in this ecbuild output:

-- Checking Fortran support for "finalization"
-- Checking Fortran support for "finalization" -- works
-- Feature FINAL enabled
-- FCKIT_HAVE_FINAL [1]
--   FCKIT_FINAL_FUNCTION_RESULT              = 1
--   FCKIT_FINAL_UNINITIALIZED_LOCAL          = 0
--   FCKIT_FINAL_UNINITIALIZED_INTENT_OUT     = 1
--   FCKIT_FINAL_UNINITIALIZED_INTENT_INOUT   = 0
--   FCKIT_FINAL_NOT_PROPAGATING              = 0
--   FCKIT_FINAL_NOT_INHERITING               = 0
--   FCKIT_FINAL_BROKEN_FOR_ALLOCATABLE_ARRAY = 0
--   FCKIT_FINAL_BROKEN_FOR_AUTOMATIC_ARRAY   = 0
