### PR TITLE
Stricter match condition for _fail strings

### DIFF
--- a/cmake/fortran_features/CheckFortranFeatures.cmake
+++ b/cmake/fortran_features/CheckFortranFeatures.cmake
@@ -116,7 +116,7 @@ macro(_figure_out_fortran_feature current_feature)
   # Find set of files that match current_feature, excepting _fail and _fail_compile.
   file(GLOB ALL_FEATURE_FILES "${Fortran_FEATURE_CHECK_DIR}/${current_feature}*.F90")
   foreach(filename ${ALL_FEATURE_FILES})
-    if(filename MATCHES "_fail")
+    if(filename MATCHES "(_fail|_fail_compile).F90$")
       list(REMOVE_ITEM ALL_FEATURE_FILES ${filename})
     endif()
   endforeach()


### PR DESCRIPTION
`ecbuild_check_fortran` triggers  a string match for `"_fail"` against a filename held in ecbuild, which can cause an unintended match if the path to the ecbuild installation contains this string. This is easily done in an IFS build if the branch name contains this string, because the cloned ecbuild will sit inside a directory named after the IFS branch, e.g. `.../user_cycle_fix_failures/source/ecbuild/...`

The result is that any Fortran feature being checked for is accidentally removed from the list of features to check, resulting in an empty feature list and an instant build failure:
`  CRITICAL - [Fortran] Expected to find only one feature.  Found 0 --`

Making the match condition stricter against the files it's actually looking for solves the problem.