### PR TITLE
Fix ecbuild_disable_unused_feature

### DIFF
--- a/cmake/ecbuild_features.cmake
+++ b/cmake/ecbuild_features.cmake
@@ -59,7 +59,7 @@ endfunction()
 # Disable the feature ${_name} globally (if it has not been enabled in any subproject)
 function( ecbuild_disable_unused_feature _name )
   get_property( _enabled GLOBAL PROPERTY ENABLED_FEATURES )
-  if ( NOT _name IN_LIST _enabled ) # if not already disabled
+  if ( _name IN_LIST _enabled ) # if not already disabled
     ecbuild_disable_feature( ${_name} )
   endif()
 endfunction()


### PR DESCRIPTION
This fixes an issue introduced with #69 where features that are ON by default, but then disabled according to run-time criteria such as unavailable libraries, are mistakenly reported as being enabled. This becomes problematic when one package queries another package's CMake options in order to modify its own behaviour (in this case, it was Metview querying the options of mars-client).