### PR TITLE
Add log output when overriding a global option setting

### DIFF
--- a/cmake/ecbuild_add_option.cmake
+++ b/cmake/ecbuild_add_option.cmake
@@ -159,6 +159,7 @@ macro( ecbuild_add_option )
 
   # Allow override of ENABLE_<FEATURE> with <PNAME>_ENABLE_<FEATURE> (see ECBUILD-486)
   if( DEFINED ${PNAME}_ENABLE_${_p_FEATURE} )
+    ecbuild_debug("ecbuild_add_option(${_p_FEATURE}): found ${PNAME}_ENABLE_${_p_FEATURE}=${${PNAME}_ENABLE_${_p_FEATURE}}")
     # Cache it for future reconfiguration
     set( ${PNAME}_ENABLE_${_p_FEATURE} ${${PNAME}_ENABLE_${_p_FEATURE}} CACHE BOOL "Override for ENABLE_${_p_FEATURE}" )
     # Warn when user provides both ENABLE_<FEATURE> and <PNAME>_ENABLE_<FEATURE>, and explain precedence
@@ -168,6 +169,8 @@ macro( ecbuild_add_option )
     endif()
     # Non-cache (hard) override of ENABLE_<FEATURE> within this project scope only
     set( ENABLE_${_p_FEATURE} ${${PNAME}_ENABLE_${_p_FEATURE}} )
+    ecbuild_debug("ecbuild_add_option(${_p_FEATURE}): set ENABLE_${_p_FEATURE} from ${PNAME}_ENABLE_${_p_FEATURE}")
+    ecbuild_debug("ecbuild_add_option(${_p_FEATURE}): ENABLE_${_p_FEATURE}=${ENABLE_${_p_FEATURE}}")
   endif()
 
   ## Update the description of the feature summary


### PR DESCRIPTION
If a `<project>_ENABLE_<feature>` variable is used, it's not directly referenced in the ecbuild.log output unless both that _and_ `ENABLE_<feature>` are present (which triggers a warning). If only the project-specific variable is present and it differs from the default setting, the output can be confusing; for example, if we have `ECCODES_ENABLE_NETCDF=OFF`:
```
eccodes - DEBUG - ecbuild_add_option(NETCDF): defaults to ON
eccodes - DEBUG - ecbuild_evaluate_dynamic_condition(_NETCDF_condition): checking condition '' -> TRUE
eccodes - DEBUG - ecbuild_add_option(NETCDF): ENABLE_NETCDF not found in cache
eccodes - DEBUG - ecbuild_add_option(NETCDF): defining option ENABLE_NETCDF 'Support for GRIB to NetCDF conversion' ON
eccodes - DEBUG - ecbuild_add_option(NETCDF): ENABLE_NETCDF=ON
eccodes - DEBUG - ecbuild_add_option(NETCDF): feature disabled # !?!
```
In the last line the setting is suddenly disabled with no explanation.

The surrounding code has good logging coverage, so a few extra lines here would explain what's going on. This PR inserts a few extra lines of context:
```
...
eccodes - DEBUG - ecbuild_add_option(NETCDF): ENABLE_NETCDF=ON
eccodes - DEBUG - ecbuild_add_option(NETCDF): found ECCODES_ENABLE_NETCDF=OFF
eccodes - DEBUG - ecbuild_add_option(NETCDF): set ENABLE_NETCDF from ECCODES_ENABLE_NETCDF
eccodes - DEBUG - ecbuild_add_option(NETCDF): ENABLE_NETCDF=OFF
eccodes - DEBUG - ecbuild_add_option(NETCDF): feature disabled
```
Happy for this to be edited if you think it's now too verbose, but I think at least one extra line here would be useful.
