### PR TITLE
Add ecbuild macro to set precision for fortran real and double

### DIFF
--- a/cmake/ecbuild_set_fortran_real4_double8_flags.cmake
+++ b/cmake/ecbuild_set_fortran_real4_double8_flags.cmake
@@ -20,7 +20,6 @@
 
 include(CheckFortranCompilerFlag)
 include(ecbuild_add_fortran_flags)
-include(ecbuild_remove_fortran_flags)
 
 macro( ecbuild_set_fortran_real4_double8_flags )
 	ecbuild_debug("call ecbuild_set_fortran_real4_double8_flags()")
@@ -29,19 +28,9 @@ macro( ecbuild_set_fortran_real4_double8_flags )
 		# specific to the NEC compiler exists to deduce which compiler it is
 		check_fortran_compiler_flag("-fdefault-real=4" IS_NEC)
 		if(IS_NEC) #NEC
-			ecbuild_remove_fortran_flags( "-fdefault-real=8" )
 			ecbuild_add_fortran_flags( "-fdefault-real=4" )
-		else() #GNU
-			ecbuild_remove_fortran_flags( "-fdefault-real-8" )
-			ecbuild_remove_fortran_flags( "-fdefault-real-10" )
-			ecbuild_remove_fortran_flags( "-fdefault-real-16" )
 		endif()
-	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-		ecbuild_remove_fortran_flags( "-r8" )
-	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
-		ecbuild_remove_fortran_flags( "-r8" )
 	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
-		ecbuild_remove_fortran_flags( "-r8" )
 		ecbuild_add_fortran_flags( "-r4" )
 	else()
 		message(WARNING "Unknown Fortran compiler. Real might not be 4 bytes.")

--- a/cmake/ecbuild_set_fortran_real4_double8_flags.cmake
+++ b/cmake/ecbuild_set_fortran_real4_double8_flags.cmake
@@ -1,0 +1,49 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+##############################################################################
+#.rst:
+#
+# ecbuild_set_fortran_real4_double8_flags
+# ==========================================
+#
+# Add Fortran compiler flags to set real to 4 bytes ::
+#
+#   ecbuild_set_fortran_real4_double8_flags()
+#
+##############################################################################
+
+include(CheckFortranCompilerFlag)
+include(ecbuild_add_fortran_flags)
+include(ecbuild_remove_fortran_flags)
+
+macro( ecbuild_set_fortran_real4_double8_flags )
+	ecbuild_debug("call ecbuild_set_fortran_real4_double8_flags()")
+	if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+		# The NEC compiler also identify itself with GNU. So test if the option
+		# specific to the NEC compiler exists to deduce which compiler it is
+		check_fortran_compiler_flag("-fdefault-real=4" IS_NEC)
+		if(IS_NEC) #NEC
+			ecbuild_remove_fortran_flags( "-fdefault-real=8" )
+			ecbuild_add_fortran_flags( "-fdefault-real=4" )
+		else() #GNU
+			ecbuild_remove_fortran_flags( "-fdefault-real-8" )
+			ecbuild_remove_fortran_flags( "-fdefault-real-10" )
+			ecbuild_remove_fortran_flags( "-fdefault-real-16" )
+		endif()
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+		ecbuild_remove_fortran_flags( "-r8" )
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+		ecbuild_remove_fortran_flags( "-r8" )
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
+		ecbuild_remove_fortran_flags( "-r8" )
+		ecbuild_add_fortran_flags( "-r4" )
+	else()
+		message(WARNING "Unknown Fortran compiler. Real might not be 4 bytes.")
+	endif()
+endmacro()

--- a/cmake/ecbuild_set_fortran_real8_double8_flags.cmake
+++ b/cmake/ecbuild_set_fortran_real8_double8_flags.cmake
@@ -1,0 +1,51 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+##############################################################################
+#.rst:
+#
+# ecbuild_set_fortran_real8_double8_flags
+# ==========================================
+#
+# Add Fortran compiler flags to set real and double to 8 bytes ::
+#
+#   ecbuild_set_fortran_real8_double8_flags()
+#
+##############################################################################
+
+include(CheckFortranCompilerFlag)
+include(ecbuild_add_fortran_flags)
+include(ecbuild_remove_fortran_flags)
+
+macro( ecbuild_set_fortran_real8_double8_flags )
+	ecbuild_debug("call ecbuild_set_fortran_real8_flags()")
+	if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+		# The NEC compiler also identify itself with GNU. So test if the option
+		# specific to the NEC compiler exists to deduce which compiler it is
+		check_fortran_compiler_flag("-fdefault-real=4" IS_NEC)
+		if(IS_NEC) #NEC
+			ecbuild_remove_fortran_flags( "-fdefault-real=4" )
+			ecbuild_add_fortran_flags( "-fdefault-real=8" )
+			ecbuild_add_fortran_flags( "-fdefault-double=8" )
+		else() #GNU
+			ecbuild_remove_fortran_flags( "-fdefault-real-10" )
+			ecbuild_remove_fortran_flags( "-fdefault-real-16" )
+			ecbuild_add_fortran_flags( "-fdefault-real-8" )
+			ecbuild_add_fortran_flags( "-fdefault-double-8" )
+		endif()
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+		ecbuild_add_fortran_flags( "-r8" )
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+		ecbuild_add_fortran_flags( "-r8" )
+	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
+		ecbuild_remove_fortran_flags( "-r4" )
+		ecbuild_add_fortran_flags( "-r8" )
+	else()
+		message(WARNING "Unknown Fortran compiler. Real and double might not be 8 bytes.")
+	endif()
+endmacro()

--- a/cmake/ecbuild_set_fortran_real8_double8_flags.cmake
+++ b/cmake/ecbuild_set_fortran_real8_double8_flags.cmake
@@ -20,7 +20,6 @@
 
 include(CheckFortranCompilerFlag)
 include(ecbuild_add_fortran_flags)
-include(ecbuild_remove_fortran_flags)
 
 macro( ecbuild_set_fortran_real8_double8_flags )
 	ecbuild_debug("call ecbuild_set_fortran_real8_flags()")
@@ -29,12 +28,9 @@ macro( ecbuild_set_fortran_real8_double8_flags )
 		# specific to the NEC compiler exists to deduce which compiler it is
 		check_fortran_compiler_flag("-fdefault-real=4" IS_NEC)
 		if(IS_NEC) #NEC
-			ecbuild_remove_fortran_flags( "-fdefault-real=4" )
 			ecbuild_add_fortran_flags( "-fdefault-real=8" )
 			ecbuild_add_fortran_flags( "-fdefault-double=8" )
 		else() #GNU
-			ecbuild_remove_fortran_flags( "-fdefault-real-10" )
-			ecbuild_remove_fortran_flags( "-fdefault-real-16" )
 			ecbuild_add_fortran_flags( "-fdefault-real-8" )
 			ecbuild_add_fortran_flags( "-fdefault-double-8" )
 		endif()
@@ -43,7 +39,6 @@ macro( ecbuild_set_fortran_real8_double8_flags )
 	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
 		ecbuild_add_fortran_flags( "-r8" )
 	elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
-		ecbuild_remove_fortran_flags( "-r4" )
 		ecbuild_add_fortran_flags( "-r8" )
 	else()
 		message(WARNING "Unknown Fortran compiler. Real and double might not be 8 bytes.")

--- a/cmake/ecbuild_system.cmake
+++ b/cmake/ecbuild_system.cmake
@@ -226,6 +226,8 @@ if( NOT ECBUILD_SYSTEM_INITIALISED )
     include( ecbuild_cache )
     include( ecbuild_remove_fortran_flags )
     include( ecbuild_configure_file )
+    include( ecbuild_set_fortran_real4_double8_flags )
+    include( ecbuild_set_fortran_real8_double8_flags )
 
     if( NOT (PROJECT_NAME STREQUAL ecbuild) )
         include( ecbuild_bundle )


### PR DESCRIPTION
Hello,

I am proposing to add two new macros to ecbuild.
Some of our software at MétéoFrance use *real* variables without any kind.
Their size is defined by the compilation flags. Those configurations were managed through custom makefile or with the gmkpack tool. Since we are now trying to move to cmake/ecbuild we thought it might be a good idea to let cmake/ecbuild find the right options instead of us writing it by hand for every project.
I didn't find any function or macro to do it, so I am proposing one.
It supports the following compilers: Intel ifort, Intel ifx, GNU gfortran, NVHPC nvfortran, and NEC nfort.