### PR TITLE
Use warning for unknown build type

### DIFF
--- a/cmake/ecbuild_define_build_types.cmake
+++ b/cmake/ecbuild_define_build_types.cmake
@@ -9,7 +9,7 @@
 ############################################################################################
 # define default build type
 
-set( _BUILD_TYPE_MSG "Defined build type options are: [ None | Debug | Bit | Production | Release | RelWithDebInfo ]" )
+set( _BUILD_TYPE_MSG "Build type options defined by ecbuild are: [ None | Debug | Bit | Production | Release | RelWithDebInfo ]" )
 
 if( NOT ECBUILD_DEFAULT_BUILD_TYPE )
     set( ECBUILD_DEFAULT_BUILD_TYPE "RelWithDebInfo" )
@@ -55,5 +55,5 @@ if( NOT CMAKE_BUILD_TYPE MATCHES "None"  AND
     NOT CMAKE_BUILD_TYPE MATCHES "Production" AND
     NOT CMAKE_BUILD_TYPE MATCHES "Release"  AND
     NOT CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo" )
-    ecbuild_warn( "CMAKE_BUILD_TYPE is not recognized. ${_BUILD_TYPE_MSG}" )
+  ecbuild_warn( "CMAKE_BUILD_TYPE is not recognized. ${_BUILD_TYPE_MSG}. Please make sure your build system correctly handles CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}.")
 endif()

--- a/cmake/ecbuild_define_build_types.cmake
+++ b/cmake/ecbuild_define_build_types.cmake
@@ -9,7 +9,7 @@
 ############################################################################################
 # define default build type
 
-set( _BUILD_TYPE_MSG "Build type options are: [ None | Debug | Bit | Production | Release | RelWithDebInfo ]" )
+set( _BUILD_TYPE_MSG "Defined build type options are: [ None | Debug | Bit | Production | Release | RelWithDebInfo ]" )
 
 if( NOT ECBUILD_DEFAULT_BUILD_TYPE )
     set( ECBUILD_DEFAULT_BUILD_TYPE "RelWithDebInfo" )
@@ -22,7 +22,7 @@ endif()
 # capitalize the build type for easy use with conditionals
 string( TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_CAPS )
 
-# correct capitatlization of the build type
+# correct capitalization of the build type
 
 if( CMAKE_BUILD_TYPE_CAPS STREQUAL "NONE" )
   set(CMAKE_BUILD_TYPE None CACHE STRING ${_BUILD_TYPE_MSG} FORCE )
@@ -50,10 +50,10 @@ endif()
 
 # fail if build type is not one of the defined ones
 if( NOT CMAKE_BUILD_TYPE MATCHES "None"  AND
-      NOT CMAKE_BUILD_TYPE MATCHES "Debug" AND
-      NOT CMAKE_BUILD_TYPE MATCHES "Bit" AND
-      NOT CMAKE_BUILD_TYPE MATCHES "Production" AND
+    NOT CMAKE_BUILD_TYPE MATCHES "Debug" AND
+    NOT CMAKE_BUILD_TYPE MATCHES "Bit" AND
+    NOT CMAKE_BUILD_TYPE MATCHES "Production" AND
     NOT CMAKE_BUILD_TYPE MATCHES "Release"  AND
     NOT CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo" )
-    ecbuild_critical( "CMAKE_BUILD_TYPE is not recognized. ${_BUILD_TYPE_MSG}" )
+    ecbuild_warn( "CMAKE_BUILD_TYPE is not recognized. ${_BUILD_TYPE_MSG}" )
 endif()


### PR DESCRIPTION
Closes #33 

As stated in #33, our group (who are 'mild' users of ecbuild; we like some of your macros), have our own set of `CMAKE_BUILD_TYPE`: `Debug`, `Release`, and `Aggressive`. That last one, of course, isn't recognized by ecbuild.

For a while, we've been maintaining a fork and at this point, the only difference is [code in `cmake/ecbuild_define_build_types.cmake`](https://github.com/ecmwf/ecbuild/compare/develop...GEOS-ESM:ecbuild:geos/develop) to make `Aggressive` allowed.

In #33, @wdeconinck suggested perhaps relaxing from `ecbuild_critical` to `ecbuild_warn`. I've done this here and tried to make the warning informative, e.g.:

```
CMake Warning at @cmake/@ecbuild/cmake/ecbuild_log.cmake:162 (message):
  WARN - CMAKE_BUILD_TYPE is not recognized.  Build type options defined
  by ecbuild are: [ None | Debug | Bit | Production | Release |
  RelWithDebInfo ].  Please make sure your build system correctly handles
  CMAKE_BUILD_TYPE=Aggressive.
Call Stack (most recent call first):
  @cmake/@ecbuild/cmake/ecbuild_define_build_types.cmake:58 (ecbuild_warn)
  @cmake/@ecbuild/cmake/ecbuild_system.cmake:115 (include)
  @cmake/esma.cmake:34 (include)
  CMakeLists.txt:47 (include)
```

Let me know if you would like changes or for me to close this. I have no problem maintaining a fork if needed (and in truth, we will probably always use a fork for internal reasons).