### PR TITLE
Allow ecbuild_add_<lang>_flags with a  LIST argument

### DIFF
--- a/cmake/ecbuild_add_c_flags.cmake
+++ b/cmake/ecbuild_add_c_flags.cmake
@@ -37,7 +37,7 @@ include(ecbuild_add_lang_flags)
 
 macro( ecbuild_add_c_flags )
     ecbuild_debug("call ecbuild_add_c_flags( ${ARGV} )")
-    ecbuild_add_lang_flags( ${ARGV} LANG C )
+    ecbuild_add_lang_flags( FLAGS ${ARGV} LANG C )
 endmacro()
 
 macro( cmake_add_c_flags )

--- a/cmake/ecbuild_add_cxx_flags.cmake
+++ b/cmake/ecbuild_add_cxx_flags.cmake
@@ -37,7 +37,7 @@ include(ecbuild_add_lang_flags)
 
 macro( ecbuild_add_cxx_flags )
     ecbuild_debug("call ecbuild_add_cxx_flags( ${ARGV} )")
-    ecbuild_add_lang_flags( ${ARGV} LANG CXX )
+    ecbuild_add_lang_flags( FLAGS ${ARGV} LANG CXX )
 endmacro()
 
 macro( cmake_add_cxx_flags )

--- a/cmake/ecbuild_add_fortran_flags.cmake
+++ b/cmake/ecbuild_add_fortran_flags.cmake
@@ -40,8 +40,8 @@ include( CheckFortranCompilerFlag )
 include(ecbuild_add_lang_flags)
 
 macro( ecbuild_add_fortran_flags )
-    ecbuild_debug("call ecbuild_add_fortran_flags( ${ARGV} )")
-    ecbuild_add_lang_flags( ${ARGV} LANG Fortran )
+  ecbuild_debug("call ecbuild_add_fortran_flags( ${ARGV} )")
+  ecbuild_add_lang_flags( FLAGS ${ARGV} LANG Fortran )
 endmacro()
 
 macro( cmake_add_fortran_flags )

--- a/cmake/ecbuild_add_lang_flags.cmake
+++ b/cmake/ecbuild_add_lang_flags.cmake
@@ -17,11 +17,11 @@
 #
 # Add compiler flags to the CMAKE_${lang}_FLAGS only if supported by compiler. ::
 #
-#   ecbuild_add_lang_flags( <flag1> [ <flag2> ... ]
-#                          LANG [C|CXX|Fortran]
-#                          [ BUILD <build> ]
-#                          [ NAME <name> ]
-#                          [ NO_FAIL ] )
+#   ecbuild_add_lang_flags( FLAGS <flag1> [ <flag2> ... ]
+#                           LANG [C|CXX|Fortran]
+#                           [ BUILD <build> ]
+#                           [ NAME <name> ]
+#                           [ NO_FAIL ] )
 #
 # Options
 # -------
@@ -40,15 +40,13 @@
 #
 ##############################################################################
 
-function( ecbuild_add_lang_flags _in_flags )
+function( ecbuild_add_lang_flags )
 
   ecbuild_debug("call ecbuild_add_lang_flags( ${ARGV} )")
 
-  set( _flags ${_in_flags} )
-
   set( options NO_FAIL )
   set( single_value_args BUILD NAME LANG )
-  set( multi_value_args )
+  set( multi_value_args FLAGS )
 
   cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}"  ${_FIRST_ARG} ${ARGN} )
 
@@ -57,6 +55,20 @@ function( ecbuild_add_lang_flags _in_flags )
   else()
     ecbuild_critical("ecbuild_add_lang_flags() called without LANG parameter")
   endif()
+
+  if(DEFINED _PAR_FLAGS)
+    set(_flags ${_PAR_FLAGS})
+  else()
+    list(FIND ARGV FLAGS ARG_FOUND)
+    if( ARG_FOUND  STREQUAL -1 )
+      ecbuild_critical("ecbuild_add_lang_flags() called without FLAGS parameter")
+    endif()
+    return()
+  endif()
+
+  # To handle the case where FLAGS is a list
+  string( REPLACE ";" " " _flags "${_flags}" )
+
 
   ecbuild_debug( "CMAKE_${_lang}_COMPILER_LOADED [${CMAKE_${_lang}_COMPILER_LOADED}]" )
 

--- a/examples/fortran-compile-options/CMakeLists.txt
+++ b/examples/fortran-compile-options/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.16)
+
+find_package(ecbuild HINTS ${CMAKE_CURRENT_SOURCE_DIR}/../.. )
+
+project( fortran_compile_options VERSION 0.0.0 LANGUAGES Fortran )
+
+
+#######################################################################################################
+### Compilation without affecting this scope, using target_compile_options
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL4)
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL8 -fdefault-real-8 -fdefault-double-8)
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL4 -r4)
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL8 -r8)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL4)
+  set(ECBUILD_Fortran_COMPILE_OPTIONS_REAL8 -r8)
+endif()
+
+# Compile program in single precision
+ecbuild_add_executable(TARGET main_r4 SOURCES main.F90)
+target_compile_options(main_r4 PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${ECBUILD_Fortran_COMPILE_OPTIONS_REAL4}>)
+
+# Compile program in double precision
+ecbuild_add_executable(TARGET main_r8 SOURCES main.F90)
+target_compile_options(main_r8 PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${ECBUILD_Fortran_COMPILE_OPTIONS_REAL8}>)
+
+#######################################################################################################
+### Compilation affecting this scope. Warning, also targets above in this scope are affected!
+
+# We can add flags as a single argument with semi-colon separated options as given by list
+ecbuild_add_fortran_flags( -Dfoo;-Dbar )
+
+# We can add flags as a expanded list
+ecbuild_add_fortran_flags( -Dbas -Dbaz )
+
+# Test that we can add an empty variable
+set( empty )
+ecbuild_add_fortran_flags( ${empty} )
+
+ecbuild_add_executable(TARGET main SOURCES main.F90)
+

--- a/examples/fortran-compile-options/main.F90
+++ b/examples/fortran-compile-options/main.F90
@@ -1,0 +1,7 @@
+program main
+use, intrinsic :: iso_c_binding, only : c_sizeof
+REAL :: variable
+write(0,'("c_sizeof(REAL): ",I0)') c_sizeof(variable)
+
+
+end program


### PR DESCRIPTION
In more recent CMake the COMPILE_FLAGS property on targets is deprecated in favour of the COMPILE_OPTIONS property. This COMPILE_OPTIONS property can be set on targets using
```
target_compile_options(my_target PUBLIC -foption1 -foption2)
```
or
```
target_compile_options(my_target PUBLIC -foption1;-foption2)
```
Important to note is that the COMPILE_OPTIONS is a cmake LIST.

Currently the signature of functions `ecbuild_add_fortran_flags`, `ecbuild_add_c_flags`, `ecbuild_add_cxx_flags` were expecting that the flags were given as a space-separated string, and not a LIST.
This PR tries to also allow a LIST argument for the flags to be more flexible and interoperate better with the more modern COMPILE_OPTIONS.