### PR TITLE
Remove ECBUILD_2_COMPAT related test

### DIFF
--- a/tests/ecbuild_add_option/build-and-run.sh
+++ b/tests/ecbuild_add_option/build-and-run.sh
@@ -10,29 +10,7 @@ export PATH=$SOURCE/../../bin:$PATH
 echo $PATH
 echo $SOURCE
 
-run_test_ECBUILD_2_COMPAT() {
-    local tname=ECBUILD_2_COMPAT__$1
-    local exp_sts=$2
-    shift 2
-
-    local bdir=$HERE/build_$tname
-    local logf=$HERE/$tname.log
-
-    mkdir -p $bdir && cd $bdir
-    local sts=0
-    echo "Running test '$tname'"
-    ecbuild -- -DECBUILD_2_COMPAT=ON -Wno-deprecated $* $SOURCE/test_project >$logf 2>&1 || sts=$?
-
-    if [[ $sts -ne $exp_sts ]] ; then
-        echo "Test '$tname': expected exit code $exp_sts, got $sts"
-        cat $logf
-        exit 1
-    fi
-}
-
 run_test() {
-
-    run_test_ECBUILD_2_COMPAT "$@"
 
     local tname=$1
     local exp_sts=$2

--- a/tests/ecbuild_add_option/test_project/CMakeLists.txt
+++ b/tests/ecbuild_add_option/test_project/CMakeLists.txt
@@ -18,11 +18,6 @@ ecbuild_add_option(FEATURE TEST_G CONDITION COND_G)
 ecbuild_add_option(FEATURE TEST_H REQUIRED_PACKAGES "foo 1.2" )         # should pass as available is version 1.2.3
 ecbuild_add_option(FEATURE TEST_I REQUIRED_PACKAGES "foo VERSION 1.2" ) # should pass as available is version 1.2.3
 
-if( ECBUILD_2_COMPAT ) # bug present with ECBUILD_2_COMPAT=ON, which will prevent a following find_package with more strict version requirement
- set( foo_FOUND 0 )
- set( FOO_FOUND 0 )
-endif()
-
 ecbuild_add_option(FEATURE TEST_J REQUIRED_PACKAGES "foo 2.1" )         # should fail as available is version 1.2.3
 ecbuild_add_option(FEATURE TEST_K REQUIRED_PACKAGES "foo VERSION 2.1" ) # should fail as available is version 1.2.3
 


### PR DESCRIPTION
This particular test failed when running with CMake 4.x, and some of the OLD policies have been effectively removed.

Since ecbuild now requires the use of CMake 3.18 it no longer makes sense to keep tests that require compatibility with CMake 2.x.

Note: this is a quick fix to prevent this particular test from failing, but a more overall update is required to remove the unnecessary code dealing with CMake 2.x compatibility.

This resolves issue #97.