### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/cmake/ecbuild_add_large_file_support.cmake
+++ b/cmake/ecbuild_add_large_file_support.cmake
@@ -17,7 +17,7 @@ macro(ecbuild_add_large_file_support)
 
   if( EC_SIZEOF_OFF_T LESS "8" )
 
-    if( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
+    if( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMAKE_SYSTEM_NAME} STREQUAL "GNU" )
       add_definitions( -D_FILE_OFFSET_BITS=64 )
     elseif( ${CMAKE_SYSTEM_NAME} MATCHES "AIX" )
       add_definitions( -D_LARGE_FILES=64 )

--- a/cmake/ecbuild_append_to_rpath.cmake
+++ b/cmake/ecbuild_append_to_rpath.cmake
@@ -49,6 +49,9 @@ function( _make_relative_rpath_entry entry var )
     elseif( EC_OS_NAME STREQUAL "aix" ) # always relative to executable path
         set( ${var} "${entry}" PARENT_SCOPE )
 
+    elseif( EC_OS_NAME STREQUAL "hurd" )
+        set( ${var} "$ORIGIN/${entry}" PARENT_SCOPE )
+
     else()
         set( ${var} "${CMAKE_INSTALL_PREFIX}/${entry}" PARENT_SCOPE )
 

--- a/cmake/ecbuild_check_os.cmake
+++ b/cmake/ecbuild_check_os.cmake
@@ -409,6 +409,12 @@ if( UNIX )
 
   endif()
 
+  ### GNU/Hurd ###
+
+  if( ${CMAKE_SYSTEM_NAME} STREQUAL "GNU" )
+    set( EC_OS_NAME "hurd" )
+  endif()
+
 endif()
 
 ### Cygwin


### PR DESCRIPTION
GNU/Hurd is a POSIX OS using a GNU toolchain close to what available on Linux, so:
- add the basic OS name identification
- use `-D_FILE_OFFSET_BITS=64` to enable the large file support
- make use of `$ORIGIN` for RPATH