### PR TITLE
Handle NAG compiler

### DIFF
--- a/cmake/ecbuild_compile_options.cmake
+++ b/cmake/ecbuild_compile_options.cmake
@@ -153,6 +153,7 @@ ecbuild_define_compile_options(
   IntelLLVM   # empty (default)
   Cray        # empty (default)
   Flang       # empty (default)
+  NAG         # empty (default)
 )
 
 ### ECBUILD_Fortran_COMPILE_OPTIONS_REAL8
@@ -169,6 +170,7 @@ ecbuild_define_compile_options(
   IntelLLVM   -r8
   Cray        -sreal64
   Flang       -fdefault-real-8
+  NAG         -double
 )
 
 ### ECBUILD_Fortran_COMPILE_OPTIONS_CHECK_BOUNDS

--- a/cmake/ecbuild_compile_options.cmake
+++ b/cmake/ecbuild_compile_options.cmake
@@ -52,7 +52,7 @@
 #
 #   ecbuild_define_compile_options( NAME <name> DESCRIPTION <description> LANGUAGE <language> [ REQUIRED ]
 #                                   [ GNU <values> ] [ NEC <values> ] [ NVHPC <values> ] [ Intel <values> ]
-#                                   [ IntelLLVM <values> ] [ Cray <values> ] [ Flang <values> ] )
+#                                   [ IntelLLVM <values> ] [ Cray <values> ] [ Flang <values> ] [ NAG <values> ] )
 #
 # Options
 # -------
@@ -87,6 +87,9 @@
 # Flang <values> : optional
 #   The values for the compile option for Flang compiler and given LANGUAGE
 #
+# NAG <values> : optional
+#   The values for the compile option for NAG compiler and given LANGUAGE
+#
 # REQUIRED : optional
 #   fail if the compile_options for the current compiler are not implemented,
 #   to avoid nasty surpises
@@ -95,7 +98,7 @@
 
 
 function( ecbuild_define_compile_options )
-  set( supported_compiler_ids GNU NEC NVHPC Intel IntelLLVM Cray Flang )
+  set( supported_compiler_ids GNU NEC NVHPC Intel IntelLLVM Cray Flang NAG )
 
   set( options REQUIRED )
   set( single_value_args NAME DESCRIPTION LANGUAGE )


### PR DESCRIPTION
This updates ecbuild_compile_options.cmake to handle the NAG compiler.