### PR TITLE
fix(CI): Correct trigger of PR-CIs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
   private-downstream-ci:
     name: private-downstream-ci
     needs: [downstream-ci]
-    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    if: ${{ (success() || failure()) && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -66,7 +66,7 @@ jobs:
   private-downstream-ci-hpc:
     name: private-downstream-ci-hpc
     needs: [downstream-ci-hpc]
-    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    if: ${{ (success() || failure()) && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
This PR follows changes made to [documentation](https://confluence.ecmwf.int/display/DS/Checklist%3A+How+to+add+a+package+to+downstream+CI).