### PR TITLE
Ensure Python 3 is available for tests

### DIFF
--- a/tests/ecbuild_find_python/configure.sh
+++ b/tests/ecbuild_find_python/configure.sh
@@ -22,6 +22,14 @@ export PATH=$SOURCE/../../bin:$PATH
 echo $PATH
 echo $SOURCE
 
+# Ensure Python 3.x is available
+if [[ "$(type -t module)" == "function" ]];
+then
+  # "module()" is available when running on HPC
+  module load python3
+  python3 --version
+fi
+
 # --------------------- cleanup ------------------------
 $SOURCE/clean.sh
 


### PR DESCRIPTION

Since the last HPC upgrade, the CMake capability to find the system python seems to have been affected. These changes load the default python3 module on the HPC, to support the tests.