### PR TITLE
Handle LLVM Flang

### DIFF
--- a/cmake/ecbuild_compile_options.cmake
+++ b/cmake/ecbuild_compile_options.cmake
@@ -18,7 +18,7 @@
 #   - ``ECBUILD_Fortran_COMPILE_OPTIONS_REAL4`` : Convert all unqualified REALs to 32 bit (single precision)
 #   - ``ECBUILD_Fortran_COMPILE_OPTIONS_REAL8`` : Convert all unqualified REALs to 64 bit (double precision)
 #   - ``ECBUILD_Fortran_COMPILE_OPTIONS_CHECK_BOUNDS`` : Bounds checking compile options
-#   - ``ECBUILD_Fortran_COMPILE_OPTIONS_INIT_SNAN`` : Compile options to initiaize REAL's with signaling NaN
+#   - ``ECBUILD_Fortran_COMPILE_OPTIONS_INIT_SNAN`` : Compile options to initialize REAL's with signaling NaN
 #   - ``ECBUILD_Fortran_COMPILE_OPTIONS_FPE_TRAP`` : Compile options to trap floating-point-exceptions
 #
 # Example use:
@@ -200,7 +200,7 @@ ecbuild_define_compile_options(
 
 ecbuild_define_compile_options(
   NAME        ECBUILD_Fortran_COMPILE_OPTIONS_INIT_SNAN
-  DESCRIPTION "Compile options to initiaize REAL's with signaling NaN"
+  DESCRIPTION "Compile options to initialize REAL's with signaling NaN"
   LANGUAGE    Fortran
   GNU         -finit-real=snan
   Intel       -init=snan


### PR DESCRIPTION
This PR adds support for LLVM Flang. This is *not* the same compiler as `Flang`, which is already supported. Note that AMD's new AFAR compiler is based on LLVM Flang, and that will be covered by this PR too (CMake doesn't distinguish between official LLVM Flang and AMD AFAR, they are both `LLVMFlang`).