### PR TITLE
Remove module load python3

### DIFF
--- a/tests/ecbuild_find_python/configure.sh
+++ b/tests/ecbuild_find_python/configure.sh
@@ -26,7 +26,6 @@ echo $SOURCE
 if [[ "$(type -t module)" == "function" ]];
 then
   # "module()" is available when running on HPC
-  module load python3
   python3 --version
 fi
 


### PR DESCRIPTION
### Description

Remove module load python3 from ecbuild_test_python script.  Addresses #109.

I don't know why the module load is needed.  The very next line tests that python3 is in $PATH and runs.  Why does it matter if it is loaded via a module or not?

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 