### PR TITLE
Added default compiler flags for CrayClang compilers

### DIFF
--- a/cmake/compiler_flags/CrayClang_C.cmake
+++ b/cmake/compiler_flags/CrayClang_C.cmake
@@ -1,0 +1,13 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+set( CMAKE_C_FLAGS_RELEASE        "-O3 -DNDEBUG"    CACHE STRING "C compiler flags for Release builds"          FORCE )
+set( CMAKE_C_FLAGS_BIT            "-O2 -DNDEBUG"    CACHE STRING "C compiler flags for Bit-reproducible builds" FORCE )
+set( CMAKE_C_FLAGS_DEBUG          "-O0 -g"          CACHE STRING "C compiler flags for Debug builds"            FORCE )
+set( CMAKE_C_FLAGS_PRODUCTION     "-O3 -g"          CACHE STRING "C compiler flags for Production builds."      FORCE )
+set( CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG" CACHE STRING "C compiler flags for RelWithDebInfo builds."  FORCE )

--- a/cmake/compiler_flags/CrayClang_CXX.cmake
+++ b/cmake/compiler_flags/CrayClang_CXX.cmake
@@ -1,0 +1,13 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+set( CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG"    CACHE STRING "C++ compiler flags for Release builds"          FORCE )
+set( CMAKE_CXX_FLAGS_BIT            "-O2 -DNDEBUG"    CACHE STRING "C++ compiler flags for Bit-reproducible builds" FORCE )
+set( CMAKE_CXX_FLAGS_DEBUG          "-O0 -g"          CACHE STRING "C++ compiler flags for Debug builds"            FORCE )
+set( CMAKE_CXX_FLAGS_PRODUCTION     "-O3 -g"          CACHE STRING "C++ compiler flags for Production builds."      FORCE )
+set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG" CACHE STRING "C++ compiler flags for RelWithDebInfo builds."  FORCE )


### PR DESCRIPTION
### Description

ecBuild was lacking default compile flags for recent Cray compilers (Cray >= 17.0.0). The reason for this is that the Cray>=17.0.0 C/C++ compilers identify as `CrayClang` in CMake, instead of `Cray` (which older compiler versions used). The Cray Fortran compiler is not affected as this still identifies as `Cray`.

As the >=17.0.0 C/C++ compilers are Clang based and are not compatible with the old `Cray` compile flags, I've copied the existing `Clang` compiler flag defaults and used them as a base for the `CrayClang` compiler flags.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
> [!WARNING]
>  I have **NOT** added or updated tests to verify that my changes are effective and functional. No test framework is available to verify these changes (would require the availability of the Cray compiler in Github Actions)
* I have run all existing tests and confirmed they pass.
 