### PR TITLE
Disable ecbuild_find_python test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,10 @@ add_subdirectory( ecbuild_add_option )
 add_subdirectory( ecbuild_add_option_multiproject_defaults )
 add_subdirectory( ecbuild_add_flags )
 add_subdirectory( ecbuild_find_package )
-add_subdirectory( ecbuild_find_python )
+# add_subdirectory( ecbuild_find_python ) 
+#
+#  Important: The test above is disabled due to CMake's inability to find the system Python (3.6.8) on the HPC.
+#    
 add_subdirectory( find_ecbuild )
 add_subdirectory( ecbuild_shared_libs )
 add_subdirectory( interface_library )


### PR DESCRIPTION
The test above is disabled due to CMake's inability to find the system Python (3.6.8) on the HPC.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 