### PR TITLE
Added OpenBSD OS detection

### DIFF
--- a/cmake/ecbuild_check_os.cmake
+++ b/cmake/ecbuild_check_os.cmake
@@ -312,6 +312,12 @@ if( UNIX )
     set( EC_OS_NAME "freebsd" )
   endif()
 
+  ### OpenBSD ###
+
+  if( ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" )
+    set( EC_OS_NAME "openbsd" )
+  endif()
+
   ### Solaris ###
 
   if( ${CMAKE_SYSTEM_NAME} MATCHES "SunOS" )


### PR DESCRIPTION
Resolves: ecmwf/eccodes#360

### Description

Recently a prerelease of ecCodes has been added to the OpenBSD ports.  For the upcoming 2.44.0, it would be nice to drop `-DDISABLE_OS_CHECK` from the port.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* ~~I have added or updated tests to verify that my changes are effective and functional.~~
* ~~I have run all existing tests and confirmed they pass.~~

I have not run tests, but the contribution is trivial.