### PR TITLE
Enforce C linking language when using LLVMFortran on Darwin 

### DIFF
--- a/cmake/ecbuild_add_library.cmake
+++ b/cmake/ecbuild_add_library.cmake
@@ -464,6 +464,11 @@ function( ecbuild_add_library_impl )
       endif()
     endif()
 
+    if( "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "LLVMFlang" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+      ecbuild_debug("ecbuild_add_library(${_PAR_TARGET}): enforce linker language C for FLANG")
+      set_target_properties( ${_PAR_TARGET} PROPERTIES LINKER_LANGUAGE C )
+    endif()
+
     if( NOT _PAR_TYPE MATCHES "OBJECT" AND NOT _PAR_TYPE MATCHES "INTERFACE" AND ECBUILD_IMPLICIT_LINK_LIBRARIES )
       target_link_libraries( ${_PAR_TARGET} PRIVATE ${ECBUILD_IMPLICIT_LINK_LIBRARIES} )
     endif()


### PR DESCRIPTION
### Description

Flang compiler doesn't recognize macOS-specific linker flags used by CMake:
e.g. when compiling Fiat:
flang-21: error: unknown argument: '-dynamiclib' 
 flang-21: error: unknown argument: '-install_name'

Following the hint from:
https://github.com/HDFGroup/hdf5/issues/5662
it seems that the fix is to simply enforce C as a linker language for LLVMFortran. 
This indeed seems to enable Fiat compilation with flang-21.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 