### PR TITLE
Add MinSizeRel as valid CMAKE_BUILD_TYPE

### DIFF
--- a/cmake/ecbuild_define_build_types.cmake
+++ b/cmake/ecbuild_define_build_types.cmake
@@ -54,7 +54,8 @@ if( NOT CMAKE_BUILD_TYPE MATCHES "None"  AND
     NOT CMAKE_BUILD_TYPE MATCHES "Bit" AND
     NOT CMAKE_BUILD_TYPE MATCHES "Production" AND
     NOT CMAKE_BUILD_TYPE MATCHES "Release"  AND
-    NOT CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo" )
+    NOT CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo" AND
+    NOT CMAKE_BUILD_TYPE MATCHES "MinSizeRel" )
   ecbuild_warn( "CMAKE_BUILD_TYPE has an unusual value (\"${CMAKE_BUILD_TYPE_CAPS}\"). ${_BUILD_TYPE_MSG}. Please make sure your build system correctly handles CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}.")
 endif()
 


### PR DESCRIPTION
### Description

Add MinSizeRel as valid CMAKE_BUILD_TYPE -- implements the #130.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 