### PR TITLE
Revert CMAKE_NO_SYSTEM_FROM_IMPORTED to CMake default

### DIFF
--- a/cmake/ecbuild_define_options.cmake
+++ b/cmake/ecbuild_define_options.cmake
@@ -39,8 +39,6 @@ mark_as_advanced( ECBUILD_RECORD_GIT_COMMIT_SHA1 )
 
 include( CMakeDependentOption ) # make options depend on one another
 
-set( CMAKE_NO_SYSTEM_FROM_IMPORTED ON )
-
 # hide some CMake options from CMake UI
 
 mark_as_advanced( CMAKE_OSX_ARCHITECTURES CMAKE_OSX_DEPLOYMENT_TARGET CMAKE_OSX_SYSROOT )


### PR DESCRIPTION
### Description

CMAKE_NO_SYSTEM_FROM_IMPORTED controls the use of system (--isystem) vs non-system (-I) include directories for imported targets, such as those found via `find_package`.
See https://cmake.org/cmake/help/latest/variable/CMAKE_NO_SYSTEM_FROM_IMPORTED.html

This change ensures the use of the default value of CMAKE_NO_SYSTEM_FROM_IMPORTED (i.e. OFF),
meaning that system include directories are used for imported targets.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 