### PR TITLE
Fix readthedocs documentation

### DIFF
--- a/doc/cmake.py
+++ b/doc/cmake.py
@@ -50,7 +50,7 @@ class EncodedString(str):
     """
         Safely convert an object to a string, handling encoding issues.
 
-        This replaces previously used `ErrorString` and `SafeString` classes,
+        This replaces previously used `ErrorString` and `SafeString` classes (recently removed/deprecated from `docutils`),
         which were used to handle encoding errors when converting objects to strings for error messages.
     """
     def __new__(cls, obj):

--- a/doc/cmake.py
+++ b/doc/cmake.py
@@ -45,11 +45,24 @@ QtHelpBuilder.build_keywords = new_build_keywords
 
 from docutils.parsers.rst import Directive, directives
 from docutils.transforms import Transform
-try:
-    from docutils.utils.error_reporting import SafeString, ErrorString
-except ImportError:
-    # error_reporting was not in utils before version 0.11:
-    from docutils.error_reporting import SafeString, ErrorString
+
+class EncodedString(str):
+    """
+        Safely convert an object to a string, handling encoding issues.
+
+        This replaces previously used `ErrorString` and `SafeString` classes,
+        which were used to handle encoding errors when converting objects to strings for error messages.
+    """
+    def __new__(cls, obj):
+        try:
+            if isinstance(obj, bytes):
+                return super().__new__(cls, obj.decode('utf-8', errors='replace'))
+            return super().__new__(cls, str(obj))
+        except Exception:
+            try:
+                return super().__new__(cls, repr(obj))
+            except Exception:
+                return super().__new__(cls, object.__repr__(obj))
 
 from docutils import io, nodes
 
@@ -88,10 +101,10 @@ class CMakeModule(Directive):
             raise self.severe('Problems with "%s" directive path:\n'
                               'Cannot encode input file path "%s" '
                               '(wrong locale?).' %
-                              (self.name, SafeString(path)))
+                              (self.name, EncodedString(path)))
         except IOError as error:
             raise self.severe('Problems with "%s" directive path:\n%s.' %
-                              (self.name, ErrorString(error)))
+                              (self.name, EncodedString(error)))
         raw_lines = f.read().splitlines()
         f.close()
         rst = None


### PR DESCRIPTION
### Description

The types SafeString and ErrorString where provided by docutils.utils.error_reporting until version 0.11, then provided by docutils.error_reporting until version 0.18/0.21?, at which point simply disappeared.

This creates a simple wrapper class that, when the input is an object, decodes the content assuming UTF-8, otherwise the fallback is to render the content with regular python str/repr.

The readthedocs documentation based on these changes can be found at https://ecbuild.readthedocs.io/en/fix-documentation/

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 