### PR TITLE
Fix install_dependency_with_soversion

### DIFF
--- a/cmake/ecbuild_install_dependency_with_soversion.cmake
+++ b/cmake/ecbuild_install_dependency_with_soversion.cmake
@@ -42,9 +42,9 @@
 #
 ##############################################################################
 function(ecbuild_install_dependency_with_soversion _target)
-    get_target_property(_loc ${_target} IMPORTED_LOCATION)
+    get_target_property(_loc ${_target} LOCATION)
     if(NOT _loc)
-        message(FATAL_ERROR "Could not find IMPORTED_LOCATION for target ${_target}")
+        message(FATAL_ERROR "Could not find LOCATION for target ${_target}")
     endif()
 
     get_filename_component(_dir ${_loc} DIRECTORY)


### PR DESCRIPTION
Now correctly uses LOCATION instead of IMPORTED_LOCATION.

IMPORTED_LOCATION is usualy unset and replaced by
IMPORTED_LOCATION_<CONFIG>. LOCATION is set for imporeted targets, i.e. from find_package.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
