### PR TITLE
Edit `${PNAME}_<lang>_FLAGS` using macros

### DIFF
--- a/cmake/ecbuild_add_c_flags.cmake
+++ b/cmake/ecbuild_add_c_flags.cmake
@@ -17,7 +17,8 @@
 #   ecbuild_add_c_flags( <flag1> [ <flag2> ... ]
 #                        [ BUILD <build> ]
 #                        [ NAME <name> ]
-#                        [ NO_FAIL ] )
+#                        [ NO_FAIL ]
+#                        [ PROJECT ] )
 #
 # Options
 # -------
@@ -30,6 +31,11 @@
 #
 # NO_FAIL : optional
 #   do not fail if the flag cannot be added
+#
+# PROJECT : optional
+#   add flags to project specific ``${PNAME}_C_FLAGS`` and
+#   ``${PNAME}_C_FLAGS_<build>`` instead of the corresponding
+#   ``CMAKE_C_FLAGS`` variables.
 #
 ##############################################################################
 

--- a/cmake/ecbuild_add_cxx_flags.cmake
+++ b/cmake/ecbuild_add_cxx_flags.cmake
@@ -17,7 +17,8 @@
 #   ecbuild_add_cxx_flags( <flag1> [ <flag2> ... ]
 #                          [ BUILD <build> ]
 #                          [ NAME <name> ]
-#                          [ NO_FAIL ] )
+#                          [ NO_FAIL ]
+#                          [ PROJECT ] )
 #
 # Options
 # -------
@@ -30,6 +31,11 @@
 #
 # NO_FAIL : optional
 #   do not fail if the flag cannot be added
+#
+# PROJECT : optional
+#   add flags to project specific ``${PNAME}_CXX_FLAGS`` and
+#   ``${PNAME}_CXX_FLAGS_<build>`` instead of the corresponding
+#   ``CMAKE_CXX_FLAGS`` variables.
 #
 ##############################################################################
 

--- a/cmake/ecbuild_add_fortran_flags.cmake
+++ b/cmake/ecbuild_add_fortran_flags.cmake
@@ -18,7 +18,8 @@
 #   ecbuild_add_fortran_flags( <flag1> [ <flag2> ... ]
 #                              [ BUILD <build> ]
 #                              [ NAME <name> ]
-#                              [ NO_FAIL ] )
+#                              [ NO_FAIL ]
+#                              [ PROJECT ] )
 #
 # Options
 # -------
@@ -32,6 +33,11 @@
 #
 # NO_FAIL : optional
 #   do not fail if the flag cannot be added
+#
+# PROJECT : optional
+#   add flags to project specific ``${PNAME}_Fortran_FLAGS`` and
+#   ``${PNAME}_Fortran_FLAGS_<build>`` instead of the corresponding
+#   ``CMAKE_Fortran_FLAGS`` variables.
 #
 ##############################################################################
 

--- a/cmake/ecbuild_add_lang_flags.cmake
+++ b/cmake/ecbuild_add_lang_flags.cmake
@@ -21,7 +21,8 @@
 #                           LANG [C|CXX|Fortran]
 #                           [ BUILD <build> ]
 #                           [ NAME <name> ]
-#                           [ NO_FAIL ] )
+#                           [ NO_FAIL ]
+#                           [ PROJECT ] )
 #
 # Options
 # -------
@@ -38,13 +39,18 @@
 # NO_FAIL : optional
 #   do not fail if the flag cannot be added
 #
+# PROJECT : optional
+#   add flags to project specific ``${PNAME}_${lang}_FLAGS`` and
+#   ``${PNAME}_${lang}_FLAGS_<build>`` instead of the corresponding
+#   ``CMAKE_${lang}_FLAGS`` variables.
+#
 ##############################################################################
 
 function( ecbuild_add_lang_flags )
 
   ecbuild_debug("call ecbuild_add_lang_flags( ${ARGV} )")
 
-  set( options NO_FAIL )
+  set( options NO_FAIL PROJECT )
   set( single_value_args BUILD NAME LANG )
   set( multi_value_args FLAGS )
 
@@ -73,6 +79,12 @@ function( ecbuild_add_lang_flags )
   ecbuild_debug( "CMAKE_${_lang}_COMPILER_LOADED [${CMAKE_${_lang}_COMPILER_LOADED}]" )
 
   if( CMAKE_${_lang}_COMPILER_LOADED )
+
+    if( _PAR_PROJECT )
+      set( _compile_flags_base_var ${PNAME}_${_lang}_FLAGS )
+    else()
+      set( _compile_flags_base_var CMAKE_${_lang}_FLAGS )
+    endif()
 
     if( ECBUILD_TRUST_FLAGS )
       set( _flag_ok 1 )
@@ -114,11 +126,20 @@ function( ecbuild_add_lang_flags )
     if( _flag_ok )
 
       if( _PAR_BUILD )
-        set( CMAKE_${_lang}_FLAGS_${_PAR_BUILD} "${CMAKE_${_lang}_FLAGS_${_PAR_BUILD}} ${_flags}" PARENT_SCOPE )
-        ecbuild_info( "Added ${_lang} flag [${_flags}] to build type ${_PAR_BUILD}" )
+        set( _compile_flags_var ${_compile_flags_base_var}_${_PAR_BUILD} )
+        set( ${_compile_flags_var} "${${_compile_flags_var}} ${_flags}" PARENT_SCOPE )
+        if( _PAR_PROJECT )
+          ecbuild_info( "Added ${_lang} flag [${_flags}] to project build type ${_PAR_BUILD}" )
+        else()
+          ecbuild_info( "Added ${_lang} flag [${_flags}] to build type ${_PAR_BUILD}" )
+        endif()
       else()
-        set( CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_flags}" PARENT_SCOPE )
-        ecbuild_info( "Added ${_lang} flag [${_flags}]" )
+        set( ${_compile_flags_base_var} "${${_compile_flags_base_var}} ${_flags}" PARENT_SCOPE )
+        if( _PAR_PROJECT )
+          ecbuild_info( "Added ${_lang} flag [${_flags}] to project flags" )
+        else()
+          ecbuild_info( "Added ${_lang} flag [${_flags}]" )
+        endif()
       endif()
 
     elseif( _PAR_NO_FAIL )

--- a/cmake/ecbuild_remove_fortran_flags.cmake
+++ b/cmake/ecbuild_remove_fortran_flags.cmake
@@ -14,7 +14,7 @@
 #
 # Remove Fortran compiler flags from ``CMAKE_Fortran_FLAGS``. ::
 #
-#   ecbuild_remove_fortran_flags( <flag1> [ <flag2> ... ] [ BUILD <build> ] )
+#   ecbuild_remove_fortran_flags( <flag1> [ <flag2> ... ] [ BUILD <build> ] [ PROJECT ] )
 #
 # Options
 # -------
@@ -23,39 +23,62 @@
 #   remove flags from ``CMAKE_Fortran_FLAGS_<build>`` instead of
 #   ``CMAKE_Fortran_FLAGS``
 #
+# PROJECT : optional
+#   remove flags from project specific ``${PNAME}_Fortran_FLAGS`` and
+#   ``${PNAME}_Fortran_FLAGS_<build>`` instead of the corresponding
+#   ``CMAKE_Fortran_FLAGS`` variables.
+#
 ##############################################################################
 
 include( CheckFortranCompilerFlag )
 macro( ecbuild_remove_fortran_flags )
 
+  set( options PROJECT )
   set( single_value_args BUILD )
   set( multi_value_args )
-  cmake_parse_arguments( _PAR "" "${single_value_args}" "${multi_value_args}" ${ARGV} )
+  cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}" ${ARGV} )
 
   set( _flags ${_PAR_UNPARSED_ARGUMENTS} )
   if( _flags AND CMAKE_Fortran_COMPILER_LOADED )
 
     string( TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_CAPS )
 
-    if( _PAR_BUILD )
-      string( TOUPPER ${_PAR_BUILD} _PAR_BUILD_CAPS )
+    if( _PAR_PROJECT )
+      set( _compile_flags_base_var ${PNAME}_Fortran_FLAGS )
+    else()
+      set( _compile_flags_base_var CMAKE_Fortran_FLAGS )
     endif()
 
-    if( _PAR_BUILD AND (CMAKE_BUILD_TYPE_CAPS MATCHES "${_PAR_BUILD_CAPS}") )
-
+    if( _PAR_BUILD )
+      string( TOUPPER ${_PAR_BUILD} _PAR_BUILD_CAPS )
+      if( CMAKE_BUILD_TYPE_CAPS MATCHES "${_PAR_BUILD_CAPS}" )
+        set( _compile_flags_var ${_compile_flags_base_var}_${_PAR_BUILD} )
+        if( DEFINED ${_compile_flags_var} )
+          foreach( _flag ${_flags} )
+            string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" ${_compile_flags_var} "${${_compile_flags_var}}" )
+            if( _PAR_PROJECT )
+              ecbuild_debug( "Fortran FLAG [${_flag}] removed from project build type ${_PAR_BUILD}" )
+            else()
+              ecbuild_debug( "Fortran FLAG [${_flag}] removed from build type ${_PAR_BUILD}" )
+            endif()
+          endforeach()
+        endif()
+      endif()
+    else()
+      set( _compile_flags_btype_var ${_compile_flags_base_var}_${CMAKE_BUILD_TYPE_CAPS} )
       foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${_PAR_BUILD} "${CMAKE_Fortran_FLAGS_${_PAR_BUILD}}")
-        ecbuild_debug( "Fortran FLAG [${_flag}] removed from build type ${_PAR_BUILD}" )
+        if( DEFINED ${_compile_flags_btype_var} )
+          string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" ${_compile_flags_btype_var} "${${_compile_flags_btype_var}}" )
+        endif()
+        if( DEFINED ${_compile_flags_base_var} )
+          string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" ${_compile_flags_base_var} "${${_compile_flags_base_var}}" )
+        endif()
+        if( _PAR_PROJECT )
+          ecbuild_debug( "Fortran FLAG [${_flag}] removed from project flags" )
+        else()
+          ecbuild_debug( "Fortran FLAG [${_flag}] removed" )
+        endif()
       endforeach()
-
-    elseif( NOT _PAR_BUILD )
-
-      foreach( _flag ${_flags} )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS} "${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE_CAPS}}" )
-        string(REGEX REPLACE "(^|[ ]+)${_flag}($|[ ]+)" "\\1" CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}" )
-        ecbuild_debug( "Fortran FLAG [${_flag}] removed" )
-      endforeach()
-
     endif()
 
   endif()

--- a/tests/ecbuild_add_flags/test_ecbuild_add_flags.cmake
+++ b/tests/ecbuild_add_flags/test_ecbuild_add_flags.cmake
@@ -16,8 +16,16 @@ ecbuild_add_c_flags( "-fooxxx" NO_FAIL )   # should not add to any compiler
 ecbuild_add_cxx_flags( "-O1" )              # should be able to add to (nearly) all compilers
 ecbuild_add_cxx_flags( "-barxxx" NO_FAIL )  # should not add to any compiler
 
+set(_cmake_c_flags_before_project "${CMAKE_C_FLAGS}")
+set(TESTFLAGS_C_FLAGS "-developer_owned")
+set(TESTFLAGS_C_FLAGS_RELEASE "-developer_owned_release")
+ecbuild_add_c_flags( "-O2" PROJECT )
+ecbuild_add_c_flags( "-O1" BUILD RELEASE PROJECT )
+
 message("CMAKE_C_FLAGS ${CMAKE_C_FLAGS}")
 message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
+message("TESTFLAGS_C_FLAGS ${TESTFLAGS_C_FLAGS}")
+message("TESTFLAGS_C_FLAGS_RELEASE ${TESTFLAGS_C_FLAGS_RELEASE}")
 
 if( CMAKE_C_FLAGS MATCHES "-O2" )
   message("Flag -O2 added")
@@ -59,4 +67,60 @@ if( CMAKE_CXX_FLAGS MATCHES "-fantasyflag" )
   message(FATAL_ERROR "Flag -fantasyflag wrongly added" )
 else()
   message("Successfully skipped addition of fake CXX flag -fantasyflag")
+endif()
+
+if( TESTFLAGS_C_FLAGS MATCHES "-developer_owned" AND TESTFLAGS_C_FLAGS MATCHES "-O2" )
+  message("Project C flag -O2 added")
+else()
+  message(FATAL_ERROR "Failed to add project C flag -O2" )
+endif()
+
+if( TESTFLAGS_C_FLAGS_RELEASE MATCHES "-developer_owned_release" AND TESTFLAGS_C_FLAGS_RELEASE MATCHES "-O1" )
+  message("Project C flag -O1 added to RELEASE")
+else()
+  message(FATAL_ERROR "Failed to add project C flag -O1 to RELEASE" )
+endif()
+
+if( NOT CMAKE_C_FLAGS STREQUAL "${_cmake_c_flags_before_project}" )
+  message(FATAL_ERROR "CMAKE_C_FLAGS should not change when PROJECT is used" )
+endif()
+
+set(_project_undefined_source_dir ${CMAKE_CURRENT_BINARY_DIR}/project_undefined_src)
+set(_project_undefined_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/project_undefined_build)
+file(MAKE_DIRECTORY ${_project_undefined_source_dir})
+file(WRITE ${_project_undefined_source_dir}/CMakeLists.txt [=[
+cmake_minimum_required( VERSION 3.18 FATAL_ERROR )
+
+find_package( ecbuild 3.6 REQUIRED )
+
+project(TestFlags VERSION 1.0 LANGUAGES C)
+
+include( ecbuild_add_c_flags )
+ecbuild_add_c_flags( "-O2" PROJECT )
+ecbuild_add_c_flags( "-O1" BUILD RELEASE PROJECT )
+
+if( NOT TESTFLAGS_C_FLAGS MATCHES "-O2" )
+  message(FATAL_ERROR "Failed to add project C flag -O2 when TESTFLAGS_C_FLAGS was initially undefined" )
+endif()
+
+if( NOT TESTFLAGS_C_FLAGS_RELEASE MATCHES "-O1" )
+  message(FATAL_ERROR "Failed to add project C flag -O1 to RELEASE when TESTFLAGS_C_FLAGS was initially undefined" )
+endif()
+]=])
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND}
+          -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+          -Decbuild_DIR=${ecbuild_DIR}
+          -S ${_project_undefined_source_dir}
+          -B ${_project_undefined_binary_dir}
+  RESULT_VARIABLE _project_undefined_result
+  OUTPUT_VARIABLE _project_undefined_stdout
+  ERROR_VARIABLE _project_undefined_stderr
+)
+
+if( NOT _project_undefined_result EQUAL 0 )
+  message(FATAL_ERROR
+    "ecbuild_add_c_flags(PROJECT ...) should succeed when TESTFLAGS_C_FLAGS is not defined:\n"
+    "${_project_undefined_stdout}${_project_undefined_stderr}")
 endif()

--- a/tests/ecbuild_remove_fortran_flags/test_ecbuild_remove_fortran_flags.cmake
+++ b/tests/ecbuild_remove_fortran_flags/test_ecbuild_remove_fortran_flags.cmake
@@ -18,6 +18,28 @@ function(test_remove_flags args input expected)
     endif()
 endfunction()
 
+function(test_remove_project_flags args input input_build expected expected_build)
+    set(CMAKE_BUILD_TYPE Testing)
+    set(PNAME TEST)
+    set(TEST_Fortran_FLAGS "${input}")
+    set(TEST_Fortran_FLAGS_TESTING "${input_build}")
+    ecbuild_remove_fortran_flags(${args} PROJECT)
+    if(NOT TEST_Fortran_FLAGS STREQUAL "${expected}")
+        message(FATAL_ERROR
+            "ecbuild_remove_fortran_flags(\"${args} PROJECT\"): "
+            "input \"${input}\", "
+            "output \"${TEST_Fortran_FLAGS}\", "
+            "expected \"${expected}\"")
+    endif()
+    if(NOT TEST_Fortran_FLAGS_TESTING STREQUAL "${expected_build}")
+        message(FATAL_ERROR
+            "ecbuild_remove_fortran_flags(\"${args} PROJECT\") build flags: "
+            "input \"${input_build}\", "
+            "output \"${TEST_Fortran_FLAGS_TESTING}\", "
+            "expected \"${expected_build}\"")
+    endif()
+endfunction()
+
 test_remove_flags("-g" "-g" "")
 test_remove_flags("-g" " -g" " ")
 test_remove_flags("-g" "-g " "")
@@ -41,3 +63,21 @@ test_remove_flags("-foo;-bar" "-g -bar -foo" "-g ")
 set(CMAKE_BUILD_TYPE Unused)
 test_remove_flags("-foo" "" "")
 test_remove_flags("-foo;BUILD;Unused" "" "")
+
+test_remove_project_flags("-g" "-g -foo" "unused -g" "-foo" "unused ")
+test_remove_project_flags("-g;BUILD;TESTING" "-g -foo" "unused -g" "-g -foo" "unused ")
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND}
+            -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+            -P ${CMAKE_CURRENT_LIST_DIR}/test_ecbuild_remove_fortran_flags_project_undefined.cmake
+    RESULT_VARIABLE _project_undefined_result
+    OUTPUT_VARIABLE _project_undefined_stdout
+    ERROR_VARIABLE _project_undefined_stderr
+)
+
+if(NOT _project_undefined_result EQUAL 0)
+    message(FATAL_ERROR
+        "ecbuild_remove_fortran_flags(PROJECT ...) should succeed when TEST_Fortran_FLAGS is not defined:\n"
+        "${_project_undefined_stdout}${_project_undefined_stderr}")
+endif()

--- a/tests/ecbuild_remove_fortran_flags/test_ecbuild_remove_fortran_flags_project_undefined.cmake
+++ b/tests/ecbuild_remove_fortran_flags/test_ecbuild_remove_fortran_flags_project_undefined.cmake
@@ -1,0 +1,17 @@
+set(CMAKE_Fortran_COMPILER_LOADED TRUE)
+set(CMAKE_BUILD_TYPE Testing)
+set(PNAME TEST)
+set(TEST_Fortran_FLAGS_TESTING "unused -g")
+
+include(ecbuild_log)
+include(ecbuild_remove_fortran_flags)
+
+ecbuild_remove_fortran_flags(-g PROJECT)
+
+if(DEFINED TEST_Fortran_FLAGS)
+  message(FATAL_ERROR "TEST_Fortran_FLAGS should remain undefined when removing project flags from an undefined base variable")
+endif()
+
+if(NOT TEST_Fortran_FLAGS_TESTING STREQUAL "unused ")
+  message(FATAL_ERROR "TEST_Fortran_FLAGS_TESTING should still be updated when TEST_Fortran_FLAGS is undefined")
+endif()


### PR DESCRIPTION
This PR updates the `ecbuild_add_lang_flags` and `ecbuild_remove_fortran_flags` macros to operate on `${PNAME}_<lang>_FLAGS` if the `PROJECT` option is specified.

An example of what this looks like in practice can be seen here: https://github.com/awnawab/ecwam/tree/naan-ecbuild-project-flags