### PR TITLE
Reduce redundant FindPerl calls

### DIFF
--- a/cmake/ecbuild_add_persistent.cmake
+++ b/cmake/ecbuild_add_persistent.cmake
@@ -39,7 +39,6 @@
 set( sg_perl "${CMAKE_CURRENT_LIST_DIR}/sg.pl" CACHE INTERNAL "perl script to generate persistent objects" )
 
 function( ecbuild_add_persistent )
-  ecbuild_find_perl( REQUIRED )
 
   set( options )
   set( single_value_args SRC_LIST NAMESPACE )
@@ -53,6 +52,11 @@ function( ecbuild_add_persistent )
 
   if( NOT _PAR_SRC_LIST  )
     ecbuild_critical("The call to ecbuild_add_persistent() doesn't specify the SRC_LIST.")
+  endif()
+
+  # Perl is only needed to run sg.pl over FILES argument.
+  if( _PAR_FILES )
+    ecbuild_find_perl( REQUIRED )
   endif()
 
   ecbuild_debug( "ecbuild_add_persistent: adding persistent layer for [${_PAR_FILES}]" )

--- a/cmake/ecbuild_find_perl.cmake
+++ b/cmake/ecbuild_find_perl.cmake
@@ -48,26 +48,28 @@ macro( ecbuild_find_perl )
     ecbuild_critical("Unknown keywords given to ecbuild_find_perl(): \"${_p_UNPARSED_ARGUMENTS}\"")
   endif()
 
-  find_package( Perl QUIET )
+  # Probe only once per build tree: PERL_EXECUTABLE is a cache entry, so testing
+  # it makes the probe happen once and the results are then published through
+  # the cache to every later directory scope.
+  if( NOT DEFINED PERL_EXECUTABLE )
 
-  if( NOT PERL_EXECUTABLE AND _p_REQUIRED )
-    ecbuild_critical( "Failed to find Perl (REQUIRED)" )
-  endif()
+    find_package( Perl QUIET )
 
-  if( PERL_EXECUTABLE )
-
-    execute_process( COMMAND ${PERL_EXECUTABLE} -V:version OUTPUT_VARIABLE  perl_version_output_variable  RESULT_VARIABLE  perl_version_return )
-    if( NOT perl_version_return )
-      string(REGEX REPLACE "version='([^']+)'.*" "\\1" PERL_VERSION ${perl_version_output_variable})
+    # FindPerl already determined the version
+    if( NOT PERL_VERSION )
+      set( PERL_VERSION "${PERL_VERSION_STRING}" )
     endif()
 
-    # from cmake 2.8.8 onwards
-    if( NOT PERL_VERSION_STRING )
-      set( PERL_VERSION_STRING ${PERL_VERSION} )
-    endif()
+    set( PERL_FOUND          "${PERL_FOUND}"          CACHE INTERNAL "Perl was found" )
+    set( PERL_VERSION        "${PERL_VERSION}"        CACHE INTERNAL "Perl version" )
+    set( PERL_VERSION_STRING "${PERL_VERSION_STRING}" CACHE INTERNAL "Perl version" )
 
     ecbuild_debug("ecbuild_find_perl: found perl version ${PERL_VERSION_STRING} as ${PERL_EXECUTABLE}")
 
+  endif()
+
+  if( NOT PERL_EXECUTABLE AND _p_REQUIRED )
+    ecbuild_critical( "Failed to find Perl (REQUIRED)" )
   endif()
 
 endmacro( ecbuild_find_perl )


### PR DESCRIPTION
### Description

This PR shows a possible resolution to #154.

The two commits try to show two independent axes of improvement:

`0d97926` — ecbuild_find_perl: probe Perl once per build tree

Guards `find_package(Perl)` on `PERL_EXECUTABLE` (a `find_program` cache entry) and publishes `PERL_FOUND` / `PERL_VERSION` / `PERL_VERSION_STRING` through the cache, so later directory scopes get them without re-probing.

Also drops ecbuild's redundant second `perl -V:version` — `FindPerl` has already set `PERL_VERSION_STRING`, as ecbuild's own comment (*"from cmake 2.8.8 onwards"*) acknowledges.

`b8395e1` — ecbuild_add_persistent: only require Perl when there is something to generate

Moves `ecbuild_find_perl( REQUIRED )` below the argument parsing and guards it on `FILES`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
