### PR TITLE
ecbuild_add_test: build ECBUILD_ALL_TESTS only once

### DIFF
--- a/cmake/ecbuild_add_test.cmake
+++ b/cmake/ecbuild_add_test.cmake
@@ -187,6 +187,39 @@
 #
 ##############################################################################
 
+# Flush the (deduplicated) accumulated test names into the ECBUILD_ALL_TESTS cache
+# entry.
+function( _ecbuild_flush_all_tests )
+  get_property( _all GLOBAL PROPERTY ECBUILD_ALL_TESTS_ACCUMULATOR )
+  if( _all )
+    list( REMOVE_DUPLICATES _all )
+  endif()
+  set( ECBUILD_ALL_TESTS "${_all}" CACHE INTERNAL "" )
+endfunction()
+
+# Record a test in ECBUILD_ALL_TESTS.
+# To create this list, accumulate into a global property (amortised O(1) append)
+# and rebuild the cache entry once, at the end of the top-level directory. This
+# is done using `cmake_language(DEFER)`, available in CMake >= 3.19.
+# For older CMake, fall back to a test-by-test deduplicate and insert algorithm,
+# that is O(n^2) in the number of tests. This matches ecbuild <= 3.15.
+function( _ecbuild_record_test _test )
+  if( CMAKE_VERSION VERSION_LESS 3.19 )
+    list( APPEND ECBUILD_ALL_TESTS ${_test} )
+    list( REMOVE_DUPLICATES ECBUILD_ALL_TESTS )
+    set( ECBUILD_ALL_TESTS ${ECBUILD_ALL_TESTS} CACHE INTERNAL "" )
+    return()
+  endif()
+
+  set_property( GLOBAL APPEND PROPERTY ECBUILD_ALL_TESTS_ACCUMULATOR ${_test} )
+
+  get_property( _scheduled GLOBAL PROPERTY ECBUILD_ALL_TESTS_FLUSH_SCHEDULED )
+  if( NOT _scheduled )
+    set_property( GLOBAL PROPERTY ECBUILD_ALL_TESTS_FLUSH_SCHEDULED TRUE )
+    cmake_language( DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL _ecbuild_flush_all_tests )
+  endif()
+endfunction()
+
 function( ecbuild_add_test )
 
   set( options           NO_AS_NEEDED )
@@ -522,9 +555,7 @@ function( ecbuild_add_test )
     endif()
 
     # add to the overall list of tests
-    list( APPEND ECBUILD_ALL_TESTS ${_PAR_TARGET} )
-    list( REMOVE_DUPLICATES ECBUILD_ALL_TESTS )
-    set( ECBUILD_ALL_TESTS ${ECBUILD_ALL_TESTS} CACHE INTERNAL "" )
+    _ecbuild_record_test( ${_PAR_TARGET} )
 
   endif() # _condition
 


### PR DESCRIPTION
### Description

This PR shows a possible resolution to #156 

PR changes `ecbuild_add_test` so that building `ECBUILD_ALL_TESTS` is deferred until all tests are known. This allows for a single deduplication and write call, instead N calls (as in develop).

This is accomplished by breaking up the work into helper functions and using `cmake_language( DEFER )`, introduced in CMake 3.19. Since ecbuild states a requirement on CMake 3.18, the previous O(N^2) algorithm is preserved as fallback for the case of CMake 3.18

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
