### PR TITLE
Add support for '=' and ',' in downloaded file names

### DIFF
--- a/cmake/ecbuild_get_test_data.cmake
+++ b/cmake/ecbuild_get_test_data.cmake
@@ -481,7 +481,7 @@ endfunction()\n\n" )
         endif()
         unset( _path_comps )
 
-        string( REPLACE "." "_" _name "${_file}" )
+        string( REGEX REPLACE "[.,=]" "_" _name "${_file}" )
         string( REGEX MATCH ":.*"  _md5  "${_d}" )
         string( REPLACE ":" "" _md5 "${_md5}" )
 


### PR DESCRIPTION
### Description
This pull request makes a small but important update to how the CMake script handles test data file names. Specifically, it improves file name sanitisation by replacing not only periods (`.`) but also commas (`,`) and equals signs (`=`) with underscores (`_`).

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
